### PR TITLE
Add Crysis Warhead support (64-bit only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library(LauncherBase STATIC
 	Code/Library/CPUID.h
 	Code/Library/CrashLogger.cpp
 	Code/Library/CrashLogger.h
+	Code/Library/EXELoader.cpp
+	Code/Library/EXELoader.h
 	Code/Library/OS.cpp
 	Code/Library/OS.h
 	Code/Library/PathTools.cpp

--- a/Code/Launcher/DedicatedServer/DedicatedServerLauncher.cpp
+++ b/Code/Launcher/DedicatedServer/DedicatedServerLauncher.cpp
@@ -39,7 +39,7 @@ int DedicatedServerLauncher::Run()
 	this->LoadEngine();
 	this->PatchEngine();
 
-	m_pGameStartup = LauncherCommon::StartEngine(m_dlls.pCryGame, m_params);
+	m_pGameStartup = LauncherCommon::StartEngine(m_dlls.isWarhead ? m_dlls.pEXE : m_dlls.pCryGame, m_params);
 
 	return m_pGameStartup->Run(NULL);
 }
@@ -49,10 +49,19 @@ void DedicatedServerLauncher::LoadEngine()
 	m_dlls.pCrySystem = LauncherCommon::LoadDLL("CrySystem.dll");
 
 	m_dlls.gameBuild = LauncherCommon::GetGameBuild(m_dlls.pCrySystem);
+	m_dlls.isWarhead = LauncherCommon::IsCrysisWarhead(m_dlls.gameBuild);
 
 	LauncherCommon::VerifyGameBuild(m_dlls.gameBuild);
 
-	m_dlls.pCryGame = LauncherCommon::LoadDLL("CryGame.dll");
+	if (m_dlls.isWarhead)
+	{
+		m_dlls.pEXE = LauncherCommon::LoadCrysisWarheadEXE();
+	}
+	else
+	{
+		m_dlls.pCryGame = LauncherCommon::LoadDLL("CryGame.dll");
+	}
+
 	m_dlls.pCryNetwork = LauncherCommon::LoadDLL("CryNetwork.dll");
 }
 

--- a/Code/Launcher/DedicatedServer/DedicatedServerLauncher.h
+++ b/Code/Launcher/DedicatedServer/DedicatedServerLauncher.h
@@ -10,11 +10,13 @@ class DedicatedServerLauncher
 
 	struct DLLs
 	{
+		void* pEXE;
 		void* pCryGame;
 		void* pCryNetwork;
 		void* pCrySystem;
 
 		int gameBuild;
+		bool isWarhead;
 	};
 
 	DLLs m_dlls;

--- a/Code/Launcher/Game/GameLauncher.h
+++ b/Code/Launcher/Game/GameLauncher.h
@@ -10,6 +10,7 @@ class GameLauncher
 
 	struct DLLs
 	{
+		void* pEXE;
 		void* pCryGame;
 		void* pCryAction;
 		void* pCryNetwork;
@@ -18,6 +19,7 @@ class GameLauncher
 		void* pCryRenderD3D10;
 
 		int gameBuild;
+		bool isWarhead;
 	};
 
 	DLLs m_dlls;

--- a/Code/Launcher/HeadlessServer/HeadlessServerLauncher.h
+++ b/Code/Launcher/HeadlessServer/HeadlessServerLauncher.h
@@ -15,6 +15,7 @@ class HeadlessServerLauncher : private ISystemUserCallback
 
 	struct DLLs
 	{
+		void* pEXE;
 		void* pCryGame;
 		void* pCryAction;
 		void* pCryNetwork;
@@ -22,6 +23,7 @@ class HeadlessServerLauncher : private ISystemUserCallback
 		void* pCryRenderNULL;
 
 		int gameBuild;
+		bool isWarhead;
 	};
 
 	DLLs m_dlls;

--- a/Code/Launcher/LauncherCommon.h
+++ b/Code/Launcher/LauncherCommon.h
@@ -13,9 +13,12 @@ namespace LauncherCommon
 	std::string GetRootFolderPath();
 
 	void* LoadDLL(const char* name);
+	void* LoadEXE(const char* name);
+	void* LoadCrysisWarheadEXE();
 
 	int GetGameBuild(void* pCrySystem);
 	void VerifyGameBuild(int gameBuild);
+	bool IsCrysisWarhead(int gameBuild);
 
 	void SetParamsCmdLine(SSystemInitParams& params, const char* cmdLine);
 

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -49,6 +49,13 @@ void MemoryPatch::CryAction::AllowDX9ImmersiveMultiplayer(void* pCryAction, int 
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCryAction, 0x23799D, 0x1E);
+			FillNop(pCryAction, 0x23B6A1, 0x1A);
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryAction, 0x2AF92D, 0x1E);
@@ -104,6 +111,13 @@ void MemoryPatch::CryAction::AllowDX9ImmersiveMultiplayer(void* pCryAction, int 
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryAction, 0x1D4ADA, 0x1A);
@@ -188,6 +202,12 @@ void MemoryPatch::CryAction::DisableGameplayStats(void* pCryAction, int gameBuil
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCryAction, 0x1E6706, code, sizeof(code));
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCryAction, 0x2F21D6, code, sizeof(code));
@@ -209,6 +229,13 @@ void MemoryPatch::CryAction::DisableGameplayStats(void* pCryAction, int gameBuil
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryAction, 0x2016ED, 0x7);
@@ -255,6 +282,12 @@ void MemoryPatch::CryGame::DisableIntros(void* pCryGame, int gameBuild)
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCryGame, 0x59739B, 0x9);
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryGame, 0x2EDF9D, 0x10);
@@ -301,6 +334,13 @@ void MemoryPatch::CryGame::DisableIntros(void* pCryGame, int gameBuild)
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryGame, 0x21A91D, 0xD);
@@ -372,6 +412,13 @@ void MemoryPatch::CryGame::CanJoinDX10Servers(void* pCryGame, int gameBuild)
 {
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// no multiplayer menu in Crysis Warhead
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -487,6 +534,13 @@ void MemoryPatch::CryGame::EnableDX10Menu(void* pCryGame, int gameBuild)
 
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead has this by default
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -628,6 +682,13 @@ void MemoryPatch::CryNetwork::EnablePreordered(void* pCryNetwork, int gameBuild)
 
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead does not have a pre-order version
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -680,7 +741,7 @@ void MemoryPatch::CryNetwork::EnablePreordered(void* pCryNetwork, int gameBuild)
 		case 6670:
 		case 6729:
 		{
-			// Crysis Wars does not have pre-ordered version
+			// Crysis Wars does not have a pre-order version
 			break;
 		}
 	}
@@ -695,6 +756,13 @@ void MemoryPatch::CryNetwork::AllowSameCDKeys(void* pCryNetwork, int gameBuild)
 {
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// no GameSpy in Crysis Warhead
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -787,6 +855,13 @@ void MemoryPatch::CryNetwork::FixInternetConnect(void* pCryNetwork, int gameBuil
 {
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// no GameSpy in Crysis Warhead
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -909,6 +984,13 @@ void MemoryPatch::CryNetwork::FixFileCheckCrash(void* pCryNetwork, int gameBuild
 
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead does not have file check
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -1069,6 +1151,13 @@ void MemoryPatch::CryNetwork::DisableServerProfile(void* pCryNetwork, int gameBu
 #else
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// already disabled in Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryNetwork, 0x9F435, 0x5);
@@ -1127,6 +1216,12 @@ void MemoryPatch::CrySystem::RemoveSecuROM(void* pCrySystem, int gameBuild)
 #ifdef BUILD_64BIT
 	switch (gameBuild)
 	{
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead has no SecuROM crap in CrySystem DLL
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x4659E, 0x16);
@@ -1153,7 +1248,7 @@ void MemoryPatch::CrySystem::RemoveSecuROM(void* pCrySystem, int gameBuild)
 		case 6670:
 		case 6729:
 		{
-			// Crysis Wars has no SecuROM crap in its CrySystem DLL
+			// Crysis Wars has no SecuROM crap in CrySystem DLL
 			break;
 		}
 	}
@@ -1167,6 +1262,13 @@ void MemoryPatch::CrySystem::AllowDX9VeryHighSpec(void* pCrySystem, int gameBuil
 {
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead allows Very High settings in DX9 mode by default
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -1248,7 +1350,7 @@ void MemoryPatch::CrySystem::AllowDX9VeryHighSpec(void* pCrySystem, int gameBuil
 		case 6670:
 		case 6729:
 		{
-			// Crysis Wars 1.4+ allows Very High settings in DX9 mode
+			// Crysis Wars 1.4+ allows Very High settings in DX9 mode by default
 			break;
 		}
 	}
@@ -1264,6 +1366,12 @@ void MemoryPatch::CrySystem::AllowMultipleInstances(void* pCrySystem, int gameBu
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCrySystem, 0x421EF, 0x6B);
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x420DF, 0x68);
@@ -1306,6 +1414,13 @@ void MemoryPatch::CrySystem::AllowMultipleInstances(void* pCrySystem, int gameBu
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x57ABF, 0x58);
@@ -1370,6 +1485,14 @@ void MemoryPatch::CrySystem::DisableCrashHandler(void* pCrySystem, int gameBuild
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCrySystem, 0x22BD6, 0x6);
+			FillNop(pCrySystem, 0x22BE2, 0x7);
+			FillNop(pCrySystem, 0x45EDC, 0x16);
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x22986, 0x6);
@@ -1428,6 +1551,13 @@ void MemoryPatch::CrySystem::DisableCrashHandler(void* pCrySystem, int gameBuild
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x182B7, 0x5);
@@ -1510,6 +1640,12 @@ void MemoryPatch::CrySystem::FixCPUInfoOverflow(void* pCrySystem, int gameBuild)
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCrySystem, 0x3746D, 0x1A);
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x3809D, 0x1A);
@@ -1552,6 +1688,13 @@ void MemoryPatch::CrySystem::FixCPUInfoOverflow(void* pCrySystem, int gameBuild)
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x4B970, 0x9);
@@ -1650,13 +1793,27 @@ void MemoryPatch::CrySystem::HookCPUDetect(void* pCrySystem, int gameBuild,
 
 #ifdef BUILD_64BIT
 	std::memcpy(&code[15], &handler, 8);
+
+	// CPUInfo pointer is stored at offset 0x630 instead of 0x628 in Crysis Warhead
+	if (gameBuild == 710 || gameBuild == 711)
+	{
+		code[3] = 0x30;
+	}
 #else
 	std::memcpy(&code[9], &handler, 4);
+
+	// TODO: 32-bit Crysis Warhead
 #endif
 
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCrySystem, 0x45AE0, &code, sizeof(code));
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCrySystem, 0x45851, &code, sizeof(code));
@@ -1701,6 +1858,13 @@ void MemoryPatch::CrySystem::HookCPUDetect(void* pCrySystem, int gameBuild,
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCrySystem, 0x59CD7, &code, sizeof(code));
@@ -1796,6 +1960,12 @@ void MemoryPatch::CrySystem::HookError(void* pCrySystem, int gameBuild,
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCrySystem, 0x52340, &code, sizeof(code));
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCrySystem, 0x52180, &code, sizeof(code));
@@ -1838,6 +2008,13 @@ void MemoryPatch::CrySystem::HookError(void* pCrySystem, int gameBuild,
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCrySystem, 0x655C0, &code, sizeof(code));
@@ -1920,6 +2097,10 @@ void MemoryPatch::CrySystem::HookLanguageInit(void* pCrySystem, int gameBuild,
 	{
 		code[9] = 0x58;
 	}
+	else if (gameBuild == 710 || gameBuild == 711)  // ...and 108 in Crysis Warhead
+	{
+		code[9] = 0x60;
+	}
 #else
 	unsigned char code[] = {
 		// call ISystem::GetLocalizationManager
@@ -1942,11 +2123,19 @@ void MemoryPatch::CrySystem::HookLanguageInit(void* pCrySystem, int gameBuild,
 	{
 		code[4] = 0xAC;
 	}
+	// TODO: 32-bit Crysis Warhead vtable index
 #endif
 
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCrySystem, 0x44A59, 0x146);
+			FillMem(pCrySystem, 0x44A59, &code, sizeof(code));
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x448D9, 0x146);
@@ -1997,6 +2186,13 @@ void MemoryPatch::CrySystem::HookLanguageInit(void* pCrySystem, int gameBuild,
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCrySystem, 0x56C66, 0x7B);
@@ -2094,6 +2290,12 @@ void MemoryPatch::CrySystem::HookChangeUserPath(void* pCrySystem, int gameBuild,
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCrySystem, 0x54230, &code, sizeof(code));
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCrySystem, 0x54080, &code, sizeof(code));
@@ -2136,6 +2338,13 @@ void MemoryPatch::CrySystem::HookChangeUserPath(void* pCrySystem, int gameBuild,
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillMem(pCrySystem, 0x63E30, &code, sizeof(code));
@@ -2209,7 +2418,18 @@ void MemoryPatch::CryRenderD3D9::HookAdapterInfo(void* pCryRenderD3D9, int gameB
 	};
 
 	std::memcpy(&code[5], &handler, 8);
+
+	unsigned char code_Warhead[] = {
+		0x48, 0x8B, 0xC8,                                            // mov rcx, rax
+		0x4C, 0x8B, 0xE0,                                            // mov r12, rax
+		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x0
+		0xFF, 0xD0                                                   // call rax
+	};
+
+	std::memcpy(&code_Warhead[8], &handler, 8);
 #else
+	// TODO: 32-bit Crysis Warhead
+
 	unsigned char code[] = {
 		0x55,                               // push ebp
 		0xB8, 0x00, 0x00, 0x00, 0x00,       // mov eax, 0x0
@@ -2224,6 +2444,13 @@ void MemoryPatch::CryRenderD3D9::HookAdapterInfo(void* pCryRenderD3D9, int gameB
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillNop(pCryRenderD3D9, 0xC8E6D, 0x19C);
+			FillMem(pCryRenderD3D9, 0xC8E6D, &code_Warhead, sizeof(code_Warhead));
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryRenderD3D9, 0xC6A7E, 0x18B);
@@ -2269,6 +2496,13 @@ void MemoryPatch::CryRenderD3D9::HookAdapterInfo(void* pCryRenderD3D9, int gameB
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryRenderD3D9, 0x93E8D, 0x137);
@@ -2334,9 +2568,34 @@ void MemoryPatch::CryRenderD3D9::HookAdapterInfo(void* pCryRenderD3D9, int gameB
  */
 void MemoryPatch::CryRenderD3D10::FixLowRefreshRateBug(void* pCryRenderD3D10, int gameBuild)
 {
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x31, 0xC0,              // xor eax, eax
+		0x90,                    // nop
+		0x90,                    // nop
+		0x41, 0x89, 0x40, 0x08,  // mov dword ptr ds:[r8+0x8], eax
+		0x90,                    // nop
+		0x90,                    // nop
+		0x90,                    // nop
+		0x90,                    // nop
+	};
+#else
+	// TODO: 32-bit Crysis Warhead
+#endif
+
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		{
+			FillMem(pCryRenderD3D10, 0x1B8AE4, &code, sizeof(code));
+			break;
+		}
+		case 711:
+		{
+			FillMem(pCryRenderD3D10, 0x1B8BE4, &code, sizeof(code));
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryRenderD3D10, 0x1C5ED5, 0x4);
@@ -2375,6 +2634,13 @@ void MemoryPatch::CryRenderD3D10::FixLowRefreshRateBug(void* pCryRenderD3D10, in
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryRenderD3D10, 0x16CE00, 0x6);
@@ -2456,6 +2722,14 @@ void MemoryPatch::CryRenderD3D10::HookAdapterInfo(void* pCryRenderD3D10, int gam
 	};
 
 	std::memcpy(&codeA[8], &handler, 8);
+
+	unsigned char codeA_Warhead[] = {
+		0x48, 0x8D, 0x48, 0xF8,                                      // lea rcx, qword ptr ds:[rax-0x8]
+		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x0
+		0xFF, 0xD0                                                   // call rax
+	};
+
+	std::memcpy(&codeA_Warhead[6], &handler, 8);
 #else
 	unsigned char code[] = {
 		0x50,                          // push eax
@@ -2471,6 +2745,18 @@ void MemoryPatch::CryRenderD3D10::HookAdapterInfo(void* pCryRenderD3D10, int gam
 	switch (gameBuild)
 	{
 #ifdef BUILD_64BIT
+		case 710:
+		{
+			FillNop(pCryRenderD3D10, 0xC5BFE, 0xEC);
+			FillMem(pCryRenderD3D10, 0xC5BFE, &codeA_Warhead, sizeof(codeA_Warhead));
+			break;
+		}
+		case 711:
+		{
+			FillNop(pCryRenderD3D10, 0xC5F9E, 0xEC);
+			FillMem(pCryRenderD3D10, 0xC5F9E, &codeA_Warhead, sizeof(codeA_Warhead));
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryRenderD3D10, 0xC48E7, 0xFF);
@@ -2529,6 +2815,13 @@ void MemoryPatch::CryRenderD3D10::HookAdapterInfo(void* pCryRenderD3D10, int gam
 			break;
 		}
 #else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
 		case 5767:
 		{
 			FillNop(pCryRenderD3D10, 0x95F28, 0xC8);
@@ -2633,6 +2926,13 @@ void MemoryPatch::CryRenderD3D10::HookInitAPI(void* pCryRenderD3D10, int gameBui
 
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead loads Direct3D DLLs normally by default
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{
@@ -2754,6 +3054,13 @@ void MemoryPatch::CryRenderNULL::DisableDebugRenderer(void* pCryRenderNULL, int 
 
 	switch (gameBuild)
 	{
+		case 687:
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead has no CryRenderNULL DLL
+			break;
+		}
 #ifdef BUILD_64BIT
 		case 5767:
 		{

--- a/Code/Library/EXELoader.cpp
+++ b/Code/Library/EXELoader.cpp
@@ -241,57 +241,6 @@ static void initterm(PVFV* begin, PVFV* end)
 	}
 }
 
-/*
-static bool CallGlobalConstructors(HMODULE exe)
-{
-	const IMAGE_DATA_DIRECTORY* iat_data = GetDirectoryData(exe, IMAGE_DIRECTORY_ENTRY_IAT);
-	if (!pIATData)
-	{
-		throw Error("Failed to locate IAT");
-	}
-
-	void** cpp_begin = static_cast<void**>(RVA(exe, pIATData->VirtualAddress + pIATData->Size));
-	void** cpp_end = cpp_begin;
-
-	void* pIAT = RVA(exe, pIATData->VirtualAddress);
-
-	while (*cpp_end < pIAT)
-	{
-		cpp_end++;
-	}
-
-	void** c_end = cpp_end;
-
-	if (cpp_end > cpp_begin)
-	{
-		cpp_end--;
-	}
-
-	while (*cpp_end == NULL && cpp_end > cpp_begin)
-	{
-		cpp_end--;
-	}
-
-	while (*cpp_end != NULL && cpp_end > cpp_begin)
-	{
-		cpp_end--;
-	}
-
-	void** c_begin = cpp_end;
-
-	GlobalInitializerList result;
-	result.c = reinterpret_cast<TGlobalInitializerC*>(c_begin);
-	result.c_count = c_end - c_begin;
-	result.cpp = reinterpret_cast<TGlobalInitializerCPP*>(cpp_begin);
-	result.cpp_count = cpp_end - cpp_begin;
-
-	return result;
-	// TODO
-
-	return true;
-}
-*/
-
 EXELoader::Result EXELoader::Load(const char* name)
 {
 	HMODULE exe = LoadLibraryA(name);

--- a/Code/Library/EXELoader.cpp
+++ b/Code/Library/EXELoader.cpp
@@ -1,0 +1,444 @@
+#include <cstring>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winternl.h>
+#undef NO_ERROR
+
+#include "EXELoader.h"
+
+static void* RVA(void* base, std::size_t offset)
+{
+	return static_cast<unsigned char*>(base) + offset;
+}
+
+static const void* RVA(const void* base, std::size_t offset)
+{
+	return static_cast<const unsigned char*>(base) + offset;
+}
+
+static const IMAGE_NT_HEADERS* GetPEHeader(HMODULE exe)
+{
+	const IMAGE_DOS_HEADER* dosHeader = static_cast<const IMAGE_DOS_HEADER*>(RVA(exe, 0));
+	if (dosHeader->e_magic != IMAGE_DOS_SIGNATURE)
+	{
+		return NULL;
+	}
+
+	const IMAGE_NT_HEADERS* peHeader = static_cast<const IMAGE_NT_HEADERS*>(RVA(exe, dosHeader->e_lfanew));
+	if (peHeader->Signature != IMAGE_NT_SIGNATURE)
+	{
+		return NULL;
+	}
+
+	return peHeader;
+}
+
+static const IMAGE_OPTIONAL_HEADER* GetOptionalHeader(HMODULE exe)
+{
+	const IMAGE_NT_HEADERS* peHeader = GetPEHeader(exe);
+	if (!peHeader)
+	{
+		return NULL;
+	}
+
+	const IMAGE_OPTIONAL_HEADER* optionalHeader = &peHeader->OptionalHeader;
+	if (optionalHeader->Magic != IMAGE_NT_OPTIONAL_HDR_MAGIC)
+	{
+		return NULL;
+	}
+
+	return optionalHeader;
+}
+
+static const IMAGE_SECTION_HEADER* GetSectionHeader(HMODULE exe, const char* name)
+{
+	const std::size_t nameLength = std::strlen(name);
+	if (nameLength > IMAGE_SIZEOF_SHORT_NAME)
+	{
+		return NULL;
+	}
+
+	const IMAGE_NT_HEADERS* peHeader = GetPEHeader(exe);
+	if (!peHeader)
+	{
+		return NULL;
+	}
+
+	const IMAGE_SECTION_HEADER* sections = static_cast<const IMAGE_SECTION_HEADER*>(
+		RVA(peHeader, sizeof(peHeader->Signature) + sizeof(peHeader->FileHeader)
+			+ peHeader->FileHeader.SizeOfOptionalHeader));
+
+	const unsigned int sectionCount = peHeader->FileHeader.NumberOfSections;
+
+	for (unsigned int i = 0; i < sectionCount; ++i)
+	{
+		if (std::memcmp(sections[i].Name, name, nameLength) == 0)
+		{
+			return sections + i;
+		}
+	}
+
+	return NULL;
+}
+
+static const IMAGE_DATA_DIRECTORY* GetDirectoryData(const IMAGE_OPTIONAL_HEADER* optionalHeader, unsigned int id)
+{
+	if (optionalHeader->NumberOfRvaAndSizes <= id)
+	{
+		return NULL;
+	}
+
+	const IMAGE_DATA_DIRECTORY* directoryData = &optionalHeader->DataDirectory[id];
+	if (directoryData->VirtualAddress == 0 || directoryData->Size == 0)
+	{
+		return NULL;
+	}
+
+	return directoryData;
+}
+
+namespace EX
+{
+	struct LDR_DATA_TABLE_ENTRY
+	{
+		PVOID Reserved1[2];
+		LIST_ENTRY InMemoryOrderLinks;
+		PVOID Reserved2[2];
+		PVOID DllBase;
+		PVOID EntryPoint;
+		PVOID Reserved3;
+		UNICODE_STRING FullDllName;
+		UNICODE_STRING BaseDllName;
+		// ...
+	};
+
+	struct PEB_LDR_DATA
+	{
+		BYTE Reserved1[8];
+		PVOID Reserved2[3];
+		LIST_ENTRY InMemoryOrderModuleList;
+	};
+
+	// Process Environment Block
+	struct PEB
+	{
+		BYTE Reserved1[2];
+		BYTE BeingDebugged;
+		BYTE Reserved2[1];
+		PVOID Reserved3[2];
+		PEB_LDR_DATA* Ldr;
+		// ...
+	};
+
+	// Thread Environment Block
+	struct TEB
+	{
+		PVOID Reserved1[12];
+		PEB* ProcessEnvironmentBlock;
+		// ...
+	};
+}
+
+static EX::TEB* GetTEB()
+{
+	return reinterpret_cast<EX::TEB*>(NtCurrentTeb());
+}
+
+static LIST_ENTRY* GetLoadedModuleList()
+{
+	// InMemoryOrderModuleList -> InMemoryOrderLinks in GetModuleData
+	return &GetTEB()->ProcessEnvironmentBlock->Ldr->InMemoryOrderModuleList;
+}
+
+static EX::LDR_DATA_TABLE_ENTRY* GetModuleData(LIST_ENTRY* entry)
+{
+	// InMemoryOrderLinks -> InMemoryOrderModuleList in GetLoadedModuleList
+	return CONTAINING_RECORD(entry, EX::LDR_DATA_TABLE_ENTRY, InMemoryOrderLinks);
+}
+
+static bool IsEqualNoCase(const UNICODE_STRING& a, const wchar_t* b)
+{
+	return _wcsnicmp(a.Buffer, b, a.Length / sizeof(wchar_t)) == 0;
+}
+
+static HMODULE FindLoadedDLL(const wchar_t* name)
+{
+	LIST_ENTRY* list = GetLoadedModuleList();
+
+	for (LIST_ENTRY* entry = list->Flink; entry != list; entry = entry->Flink)
+	{
+		EX::LDR_DATA_TABLE_ENTRY* data = GetModuleData(entry);
+
+		if (IsEqualNoCase(data->BaseDllName, name))
+		{
+			return static_cast<HMODULE>(data->DllBase);
+		}
+	}
+
+	return NULL;
+}
+
+static HMODULE FindLoadedDLL(const char* name)
+{
+	enum { MAX_NAME_LENGTH = 256 };
+
+	wchar_t wideName[MAX_NAME_LENGTH];
+	if (MultiByteToWideChar(CP_UTF8, 0, name, -1, wideName, MAX_NAME_LENGTH) <= 0)
+	{
+		return NULL;
+	}
+
+	return FindLoadedDLL(wideName);
+}
+
+static void* FindThunkFunction(HMODULE exe, HMODULE dll, const IMAGE_THUNK_DATA* thunk)
+{
+	const char* name = NULL;
+
+	if (IMAGE_SNAP_BY_ORDINAL(thunk->u1.Ordinal))
+	{
+		name = reinterpret_cast<const char*>(IMAGE_ORDINAL(thunk->u1.Ordinal));
+	}
+	else
+	{
+		IMAGE_IMPORT_BY_NAME* data = static_cast<IMAGE_IMPORT_BY_NAME*>(RVA(exe, thunk->u1.AddressOfData));
+
+		name = reinterpret_cast<const char*>(data->Name);
+	}
+
+	return GetProcAddress(dll, name);
+}
+
+typedef int  (*PIFV)();
+typedef void (*PVFV)();
+
+static int initterm_e(PIFV* begin, PIFV* end)
+{
+	for (PIFV* fn = begin; fn < end; ++fn)
+	{
+		if (*fn)
+		{
+			int ret = (**fn)();
+			if (ret != 0)
+			{
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static void initterm(PVFV* begin, PVFV* end)
+{
+	for (PVFV* fn = begin; fn < end; ++fn)
+	{
+		if (*fn)
+		{
+			(**fn)();
+		}
+	}
+}
+
+/*
+static bool CallGlobalConstructors(HMODULE exe)
+{
+	const IMAGE_DATA_DIRECTORY* iat_data = GetDirectoryData(exe, IMAGE_DIRECTORY_ENTRY_IAT);
+	if (!pIATData)
+	{
+		throw Error("Failed to locate IAT");
+	}
+
+	void** cpp_begin = static_cast<void**>(RVA(exe, pIATData->VirtualAddress + pIATData->Size));
+	void** cpp_end = cpp_begin;
+
+	void* pIAT = RVA(exe, pIATData->VirtualAddress);
+
+	while (*cpp_end < pIAT)
+	{
+		cpp_end++;
+	}
+
+	void** c_end = cpp_end;
+
+	if (cpp_end > cpp_begin)
+	{
+		cpp_end--;
+	}
+
+	while (*cpp_end == NULL && cpp_end > cpp_begin)
+	{
+		cpp_end--;
+	}
+
+	while (*cpp_end != NULL && cpp_end > cpp_begin)
+	{
+		cpp_end--;
+	}
+
+	void** c_begin = cpp_end;
+
+	GlobalInitializerList result;
+	result.c = reinterpret_cast<TGlobalInitializerC*>(c_begin);
+	result.c_count = c_end - c_begin;
+	result.cpp = reinterpret_cast<TGlobalInitializerCPP*>(cpp_begin);
+	result.cpp_count = cpp_end - cpp_begin;
+
+	return result;
+	// TODO
+
+	return true;
+}
+*/
+
+EXELoader::Result EXELoader::Load(const char* name)
+{
+	HMODULE exe = LoadLibraryA(name);
+	if (!exe)
+	{
+		return Result(ERROR_OPEN, GetLastError());
+	}
+
+	const IMAGE_OPTIONAL_HEADER* optionalHeader = GetOptionalHeader(exe);
+	if (!optionalHeader)
+	{
+		FreeLibrary(exe);
+		return Result(ERROR_OPTIONAL_HEADER);
+	}
+
+	const IMAGE_DATA_DIRECTORY* importData = GetDirectoryData(optionalHeader, IMAGE_DIRECTORY_ENTRY_IMPORT);
+	if (!importData)
+	{
+		FreeLibrary(exe);
+		return Result(ERROR_IMPORT_TABLE_MISSING);
+	}
+
+	const IMAGE_DATA_DIRECTORY* iatData = GetDirectoryData(optionalHeader, IMAGE_DIRECTORY_ENTRY_IAT);
+	if (!iatData)
+	{
+		FreeLibrary(exe);
+		return Result(ERROR_IAT_MISSING);
+	}
+
+	void* iat = RVA(exe, iatData->VirtualAddress);
+
+	// temporarily make IAT writable
+	DWORD iatProtection;
+	if (!VirtualProtect(iat, iatData->Size, PAGE_READWRITE, &iatProtection))
+	{
+		const DWORD sysError = GetLastError();
+		FreeLibrary(exe);
+		return Result(ERROR_IAT_VIRTUAL_PROTECT, sysError);
+	}
+
+	const IMAGE_IMPORT_DESCRIPTOR* importDescriptor =
+		static_cast<const IMAGE_IMPORT_DESCRIPTOR*>(RVA(exe, importData->VirtualAddress));
+
+	// fill IAT
+	for (; importDescriptor->Name && importDescriptor->FirstThunk; ++importDescriptor)
+	{
+		const char* dllName = static_cast<const char*>(RVA(exe, importDescriptor->Name));
+
+		// GetModuleHandleA cannot find certain DLLs
+		HMODULE dll = FindLoadedDLL(dllName);
+		if (!dll)
+		{
+			// TODO: unload previously loaded DLLs in case of error
+			dll = LoadLibraryA(dllName);
+			if (!dll)
+			{
+				const DWORD sysError = GetLastError();
+				FreeLibrary(exe);
+				return Result(ERROR_IMPORT_LOAD_LIBRARY, sysError);
+			}
+		}
+
+		IMAGE_THUNK_DATA* thunk = static_cast<IMAGE_THUNK_DATA*>(RVA(exe, importDescriptor->FirstThunk));
+
+		for (; thunk->u1.Ordinal; ++thunk)
+		{
+			void* func = FindThunkFunction(exe, dll, thunk);
+			if (!func)
+			{
+				const DWORD sysError = GetLastError();
+				FreeLibrary(exe);
+				return Result(ERROR_IAT_GET_PROC_ADDRESS, sysError);
+			}
+
+			thunk->u1.Function = reinterpret_cast<DWORD_PTR>(func);
+		}
+	}
+
+	// restore IAT protection
+	if (!VirtualProtect(iat, iatData->Size, iatProtection, &iatProtection))
+	{
+		const DWORD sysError = GetLastError();
+		FreeLibrary(exe);
+		return Result(ERROR_IAT_VIRTUAL_PROTECT_RESTORE, sysError);
+	}
+
+	const IMAGE_SECTION_HEADER* textSection = GetSectionHeader(exe, ".text");
+	if (!textSection)
+	{
+		FreeLibrary(exe);
+		return Result(ERROR_TEXT_SECTION_MISSING);
+	}
+
+	void* textBegin = RVA(exe, textSection->VirtualAddress);
+	void* textEnd = RVA(exe, textSection->VirtualAddress + textSection->Misc.VirtualSize);
+
+	void* iatEnd = RVA(exe, iatData->VirtualAddress + iatData->Size);
+
+	// make sure .rdata section exists, see below
+	if (!GetSectionHeader(exe, ".rdata"))
+	{
+		FreeLibrary(exe);
+		return Result(ERROR_RDATA_SECTION_MISSING);
+	}
+
+	// there is no way to obtain location of the two global constructor arrays
+	// VS2005 linker puts them after IAT in .rdata
+	PVFV* xc_a = static_cast<PVFV*>(iatEnd);
+	PVFV* xc_z = xc_a;
+
+	// from the beginning of the first array, find the end of the second array
+	for (PVFV* next = xc_z + 1; (*next >= textBegin && *next < textEnd) || *next == NULL; ++next)
+	{
+		xc_z = next;
+	}
+
+	// find the real end of the second array by skipping trailing null pointers
+	while (xc_z > xc_a && *xc_z == NULL)
+	{
+		--xc_z;
+	}
+
+	PIFV* xi_z = reinterpret_cast<PIFV*>(xc_z + 1);
+
+	// find the end of the first array, which is the beginning of the second array
+	while (xc_z > xc_a && *xc_z != NULL)
+	{
+		--xc_z;
+	}
+
+	PIFV* xi_a = reinterpret_cast<PIFV*>(xc_z);
+
+	// call C global constructors
+	if (initterm_e(xi_a, xi_z) != 0)
+	{
+		FreeLibrary(exe);
+		return Result(ERROR_GLOBAL_CONSTRUCTOR);
+	}
+
+	// call C++ global constructors
+	initterm(xc_a, xc_z);
+
+	return Result(exe);
+}
+
+const char* const EXELoader::errorNames[] = {
+#define X(name) #name,
+	EXE_LOADER_ERRORS
+#undef X
+};

--- a/Code/Library/EXELoader.h
+++ b/Code/Library/EXELoader.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/**
+ * Multiple EXEs loaded within a single process is normally impossible, and yet here we are.
+ */
+namespace EXELoader
+{
+#define EXE_LOADER_ERRORS \
+	X(NO_ERROR) \
+	X(ERROR_OPEN) \
+	X(ERROR_OPTIONAL_HEADER) \
+	X(ERROR_IMPORT_TABLE_MISSING) \
+	X(ERROR_IMPORT_LOAD_LIBRARY) \
+	X(ERROR_IAT_MISSING) \
+	X(ERROR_IAT_VIRTUAL_PROTECT) \
+	X(ERROR_IAT_VIRTUAL_PROTECT_RESTORE) \
+	X(ERROR_IAT_GET_PROC_ADDRESS) \
+	X(ERROR_TEXT_SECTION_MISSING) \
+	X(ERROR_RDATA_SECTION_MISSING) \
+	X(ERROR_GLOBAL_CONSTRUCTOR)
+
+	enum Error
+	{
+#define X(name) name,
+		EXE_LOADER_ERRORS
+#undef X
+	};
+
+	struct Result
+	{
+		void* exe;
+		Error error;
+		unsigned long sysError;  // GetLastError
+
+		explicit Result(void* exe) : exe(exe), error(NO_ERROR), sysError(0) {}
+		explicit Result(Error error, unsigned long sysError = 0) : exe(0), error(error), sysError(sysError) {}
+	};
+
+	Result Load(const char* name);
+
+	extern const char* const errorNames[];
+}


### PR DESCRIPTION
Close #21

32-bit version of Crysis Warhead is still not supported because of SecuROM in its EXE.

64-bit version has a separate `Bin64/Crysis64.exe` without SecuROM because that garbage does not work in 64-bit code apparently. `Bin64/Crysis.exe` is a **32**-bit SecuROM launcher, which we can safely ignore. This is not true for 32-bit version unfortunately, as it has only one `Bin32/Crysis.exe`. We would need some runtime SecuROM unpacker to support 32-bit version as well. This is starting to get shady.