### PR TITLE
Improve sys_crashtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix startup crash of Warhead launcher when Logitech G15 keyboard is connected
 ([#39](https://github.com/ccomrade/c1-launcher/issues/39)).
+### Changed
+- Improve `sys_crashtest` ([#53](https://github.com/ccomrade/c1-launcher/pull/53)).
 
 ## [v6] - 2024-02-15
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(LauncherBase STATIC
 	Code/CryCommon/CrySystem/IValidator.h
 	Code/Launcher/CPUInfo.cpp
 	Code/Launcher/CPUInfo.h
+	Code/Launcher/CrashTest.cpp
+	Code/Launcher/CrashTest.h
 	Code/Launcher/CryRender.h
 	Code/Launcher/LauncherCommon.cpp
 	Code/Launcher/LauncherCommon.h

--- a/Code/Launcher/CrashTest.cpp
+++ b/Code/Launcher/CrashTest.cpp
@@ -1,0 +1,173 @@
+#include <assert.h>
+#include <intrin.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "CryCommon/CrySystem/IConsole.h"
+#include "CryCommon/CrySystem/ISystem.h"
+
+#include "CrashTest.h"
+
+static void SegFault()
+{
+	volatile int* p = NULL;
+	*p = 0xabcd;
+}
+
+static void IntDivisionByZero()
+{
+	volatile int i = 0;
+	i /= i;
+}
+
+static void BadAllocBig()
+{
+	volatile bool b = true;
+	while (b)
+	{
+		new char[16 * 1024 * 1024];
+	}
+}
+
+static void BadAllocSmall()
+{
+	volatile bool b = true;
+	while (b)
+	{
+		new char[128];
+	}
+}
+
+static void InvalidCrtArgument()
+{
+	strcpy_s(NULL, 4, "abc");
+}
+
+static void PureVirtualCall()
+{
+	struct Base
+	{
+		Base()
+		{
+			this->Boom();
+		}
+
+		void Boom()
+		{
+			this->Call();
+		}
+
+		virtual void Call() = 0;
+	};
+
+	struct Derived : Base
+	{
+		void Call() override
+		{
+		}
+	};
+
+	Derived d;
+}
+
+static void StackOverflow()
+{
+	volatile int i = 0;
+	volatile int* p = &i;
+	volatile bool b = true;
+	while (b)
+	{
+		// stack grows downwards
+		*(--p) = 666;
+	}
+}
+
+static void CrashTestHandler(IConsoleCmdArgs* pArgs)
+{
+	if (pArgs->GetArgCount() != 2)
+	{
+		CryLogWarningAlways("'%s' requires one argument", pArgs->GetCommandLine());
+		return;
+	}
+
+	const int value = atoi(pArgs->GetArg(1));
+
+	switch (value)
+	{
+		case 1:
+		{
+			SegFault();
+			break;
+		}
+		case 2:
+		{
+			IntDivisionByZero();
+			break;
+		}
+		case 3:
+		{
+			BadAllocBig();
+			break;
+		}
+		case 4:
+		{
+			gEnv->pSystem->Error("sys_crashtest %d", value);
+			break;
+		}
+		case 5:
+		{
+			BadAllocSmall();
+			break;
+		}
+		case 6:
+		{
+			assert(0);
+			break;
+		}
+		case 7:
+		{
+			__debugbreak();
+			break;
+		}
+		case 8:
+		{
+			abort();
+			break;
+		}
+		case 9:
+		{
+			InvalidCrtArgument();
+			break;
+		}
+		case 10:
+		{
+			PureVirtualCall();
+			break;
+		}
+		case 11:
+		{
+			throw 666;
+			break;
+		}
+		case 12:
+		{
+			StackOverflow();
+			break;
+		}
+		default:
+		{
+			CryLogWarningAlways("sys_crashtest %d is not supported", value);
+			break;
+		}
+	}
+}
+
+void CrashTest::Register()
+{
+	IConsole* pConsole = gEnv->pConsole;
+
+	// disable the original cvar without removing it completely because CrySystem holds a pointer to it
+	pConsole->UnregisterVariable("sys_crashtest", false);
+
+	pConsole->AddCommand("sys_crashtest", &CrashTestHandler, 0, "Crash the game");
+}

--- a/Code/Launcher/CrashTest.h
+++ b/Code/Launcher/CrashTest.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace CrashTest
+{
+	void Register();
+}

--- a/Code/Launcher/LauncherCommon.cpp
+++ b/Code/Launcher/LauncherCommon.cpp
@@ -11,6 +11,7 @@
 #include "Library/StringView.h"
 #include "Project.h"
 
+#include "CrashTest.h"
 #include "CryRender.h"
 #include "LauncherCommon.h"
 
@@ -328,6 +329,8 @@ void LauncherCommon::OnEarlyEngineInit(ISystem* pSystem)
 	CryLogAlways("Main directory: %s", mainDir.c_str());
 	CryLogAlways("Root directory: %s", rootDir.empty() ? mainDir.c_str() : rootDir.c_str());
 	CryLogAlways("User directory: %s", userDir.c_str());
+
+	CrashTest::Register();
 }
 
 void LauncherCommon::OnD3D9Info(CryRender_D3D9_AdapterInfo* info)

--- a/Code/Library/CrashLogger.cpp
+++ b/Code/Library/CrashLogger.cpp
@@ -56,10 +56,11 @@ static const char* ExceptionCodeToName(unsigned int code)
 		case EXCEPTION_INT_DIVIDE_BY_ZERO:       return "Integer divide by zero";
 		case EXCEPTION_INT_OVERFLOW:             return "Integer overflow";
 		case EXCEPTION_INVALID_DISPOSITION:      return "Invalid disposition";
-		case EXCEPTION_NONCONTINUABLE_EXCEPTION: return "Noncontinuable exception";
+		case EXCEPTION_NONCONTINUABLE_EXCEPTION: return "Noncontinuable";
 		case EXCEPTION_PRIV_INSTRUCTION:         return "Privileged instruction";
 		case EXCEPTION_SINGLE_STEP:              return "Single step";
 		case EXCEPTION_STACK_OVERFLOW:           return "Stack overflow";
+		case 0xE06D7363:                         return "C++ EH";
 	}
 
 	return "Unknown";


### PR DESCRIPTION
It is now similar to the one in modern CryEngine and supports the following parameters:
- `1` - Null pointer access
- `2` - Integer division by zero
- `3` - Out-of-memory using big blocks
- `4` - Engine error (`ISystem::Error`)
- `5` - Out-of-memory using small blocks
- `6` - `assert(0)`
- `7` - `__debugbreak()`
- `8` - `abort()`
- `9` - Invalid CRT argument
- `10` - Pure virtual function call
- `11` - Unhandled C++ exception
- `12` - Stack overflow

This is needed for proper testing of the crash logger.