### PR TITLE
Fix CryWarning and GameWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Notable changes in each release.
 
 ## [Unreleased]
-### Fixed
+- Fix startup crash when `profile.xml` is corrupted ([#59](https://github.com/ccomrade/c1-launcher/pull/59)).
 - Fix startup crash of Warhead launcher when Logitech G15 keyboard is connected
 ([#39](https://github.com/ccomrade/c1-launcher/issues/39)).
-### Changed
 - Improve crash logger ([#53](https://github.com/ccomrade/c1-launcher/pull/53),
 [#55](https://github.com/ccomrade/c1-launcher/pull/55)).
 

--- a/Code/Launcher/DedicatedServer/DedicatedServerLauncher.h
+++ b/Code/Launcher/DedicatedServer/DedicatedServerLauncher.h
@@ -10,13 +10,13 @@ class DedicatedServerLauncher
 
 	struct DLLs
 	{
-		void* pEXE;
+		void* pWarheadExe;
 		void* pCryGame;
+		void* pCryAction;
 		void* pCryNetwork;
 		void* pCrySystem;
 
 		int gameBuild;
-		bool isWarhead;
 	};
 
 	DLLs m_dlls;

--- a/Code/Launcher/Editor/EditorLauncher.cpp
+++ b/Code/Launcher/Editor/EditorLauncher.cpp
@@ -125,6 +125,18 @@ void EditorLauncher::LoadEngine()
 	m_dlls.editorBuild = GetEditorBuild(m_dlls.pEditor);
 	VerifyEditorBuild(m_dlls.editorBuild);
 
+	if (LauncherCommon::IsCrysisWarhead(m_dlls.gameBuild))
+	{
+		m_dlls.pWarheadExe = LauncherCommon::LoadCrysisWarheadEXE();
+	}
+	else
+	{
+		m_dlls.pCryGame = LauncherCommon::LoadDLL("CryGame.dll");
+		m_dlls.pCryAction = LauncherCommon::LoadDLL("CryAction.dll");
+	}
+
+	m_dlls.pCryNetwork = LauncherCommon::LoadDLL("CryNetwork.dll");
+
 	if (LauncherCommon::IsDX10())
 	{
 		m_dlls.pCryRenderD3D10 = LauncherCommon::LoadDLL("CryRenderD3D10.dll");
@@ -143,6 +155,36 @@ void EditorLauncher::PatchEngine()
 		MemoryPatch::Editor::HookVersionInit(m_dlls.pEditor, m_dlls.editorBuild, &OnVersionInit);
 	}
 
+	if (m_dlls.pWarheadExe)
+	{
+		MemoryPatch::WarheadEXE::HookCryWarning(m_dlls.pWarheadExe, m_dlls.gameBuild,
+			&LauncherCommon::OnCryWarning);
+		MemoryPatch::WarheadEXE::HookGameWarning(m_dlls.pWarheadExe, m_dlls.gameBuild,
+			&LauncherCommon::OnGameWarning);
+	}
+
+	if (m_dlls.pCryGame)
+	{
+		MemoryPatch::CryGame::HookCryWarning(m_dlls.pCryGame, m_dlls.gameBuild,
+			&LauncherCommon::OnCryWarning);
+		MemoryPatch::CryGame::HookGameWarning(m_dlls.pCryGame, m_dlls.gameBuild,
+			&LauncherCommon::OnGameWarning);
+	}
+
+	if (m_dlls.pCryAction)
+	{
+		MemoryPatch::CryAction::HookCryWarning(m_dlls.pCryAction, m_dlls.gameBuild,
+			&LauncherCommon::OnCryWarning);
+		MemoryPatch::CryAction::HookGameWarning(m_dlls.pCryAction, m_dlls.gameBuild,
+			&LauncherCommon::OnGameWarning);
+	}
+
+	if (m_dlls.pCryNetwork)
+	{
+		MemoryPatch::CryNetwork::HookCryWarning(m_dlls.pCryNetwork, m_dlls.gameBuild,
+			&LauncherCommon::OnCryWarning);
+	}
+
 	if (m_dlls.pCrySystem)
 	{
 		MemoryPatch::CrySystem::AllowDX9VeryHighSpec(m_dlls.pCrySystem, m_dlls.gameBuild);
@@ -152,6 +194,8 @@ void EditorLauncher::PatchEngine()
 		MemoryPatch::CrySystem::HookError(m_dlls.pCrySystem, m_dlls.gameBuild, &CrashLogger::OnEngineError);
 		MemoryPatch::CrySystem::HookChangeUserPath(m_dlls.pCrySystem, m_dlls.gameBuild,
 			&LauncherCommon::OnChangeUserPath);
+		MemoryPatch::CrySystem::HookCryWarning(m_dlls.pCrySystem, m_dlls.gameBuild,
+			&LauncherCommon::OnCryWarning);
 	}
 
 	if (m_dlls.pCryRenderD3D9)

--- a/Code/Launcher/Editor/EditorLauncher.h
+++ b/Code/Launcher/Editor/EditorLauncher.h
@@ -5,6 +5,10 @@ class EditorLauncher
 	struct DLLs
 	{
 		void* pEditor;
+		void* pWarheadExe;
+		void* pCryGame;
+		void* pCryAction;
+		void* pCryNetwork;
 		void* pCrySystem;
 		void* pCryRenderD3D9;
 		void* pCryRenderD3D10;

--- a/Code/Launcher/Game/GameLauncher.h
+++ b/Code/Launcher/Game/GameLauncher.h
@@ -10,7 +10,7 @@ class GameLauncher
 
 	struct DLLs
 	{
-		void* pEXE;
+		void* pWarheadExe;
 		void* pCryGame;
 		void* pCryAction;
 		void* pCryNetwork;
@@ -19,7 +19,6 @@ class GameLauncher
 		void* pCryRenderD3D10;
 
 		int gameBuild;
-		bool isWarhead;
 	};
 
 	DLLs m_dlls;

--- a/Code/Launcher/HeadlessServer/HeadlessServerLauncher.h
+++ b/Code/Launcher/HeadlessServer/HeadlessServerLauncher.h
@@ -15,7 +15,7 @@ class HeadlessServerLauncher : private ISystemUserCallback
 
 	struct DLLs
 	{
-		void* pEXE;
+		void* pWarheadExe;
 		void* pCryGame;
 		void* pCryAction;
 		void* pCryNetwork;
@@ -23,7 +23,6 @@ class HeadlessServerLauncher : private ISystemUserCallback
 		void* pCryRenderNULL;
 
 		int gameBuild;
-		bool isWarhead;
 	};
 
 	DLLs m_dlls;

--- a/Code/Launcher/LauncherCommon.cpp
+++ b/Code/Launcher/LauncherCommon.cpp
@@ -371,6 +371,32 @@ bool LauncherCommon::OnD3D10Init(MemoryPatch::CryRenderD3D10::SystemAPI* api)
 	return true;
 }
 
+void LauncherCommon::OnCryWarning(int, int, const char* format, ...)
+{
+	// the original buffer size
+	char buffer[4096];
+
+	va_list args;
+	va_start(args, format);
+	StringFormatToBufferV(buffer, sizeof(buffer), format, args);
+	va_end(args);
+
+	CryLogWarning("%s", buffer);
+}
+
+void LauncherCommon::OnGameWarning(const char* format, ...)
+{
+	// the original buffer size
+	char buffer[4096];
+
+	va_list args;
+	va_start(args, format);
+	StringFormatToBufferV(buffer, sizeof(buffer), format, args);
+	va_end(args);
+
+	CryLogWarning("%s", buffer);
+}
+
 void LauncherCommon::LogBytes(const char* message, std::size_t bytes)
 {
 	const char* unit = "";

--- a/Code/Launcher/LauncherCommon.h
+++ b/Code/Launcher/LauncherCommon.h
@@ -44,6 +44,8 @@ namespace LauncherCommon
 	void OnD3D9Info(MemoryPatch::CryRenderD3D9::AdapterInfo* info);
 	void OnD3D10Info(MemoryPatch::CryRenderD3D10::AdapterInfo* info);
 	bool OnD3D10Init(MemoryPatch::CryRenderD3D10::SystemAPI* api);
+	void OnCryWarning(int, int, const char* format, ...);
+	void OnGameWarning(const char* format, ...);
 
 	void LogBytes(const char* message, std::size_t bytes);
 

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -1760,7 +1760,7 @@ void MemoryPatch::CrySystem::HookCPUDetect(void* pCrySystem, int gameBuild,
 		0x48, 0x89, 0x85, 0x28, 0x06, 0x00, 0x00,                    // mov qword ptr ss:[rbp+0x628], rax
 		0x48, 0x8B, 0xC8,                                            // mov rcx, rax
 		0x48, 0x8B, 0xD5,                                            // mov rdx, rbp
-		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x102030405060708
+		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x0
 		0xFF, 0xD0,                                                  // call rax
 		0x90,                                                        // nop
 		0x90,                                                        // nop
@@ -3396,6 +3396,686 @@ void MemoryPatch::Editor::HookVersionInit(void* pEditor, int editorBuild,
 		case 6670:
 		{
 			FillMem(pEditor, 0x2C1BC, &code, sizeof(code));
+			break;
+		}
+#endif
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GENERATED MEMORY PATCHES
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+// CryAction
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Used to fix the GameWarning format string vulnerability.
+ */
+void MemoryPatch::CryAction::HookGameWarning(void* pCryAction, int gameBuild, void (*handler)(const char* format, ...))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0
+		0xff, 0xe0,                                                  // jmp rax
+		0x90,                                                        // nop
+		0x90,                                                        // nop
+		0x90,                                                        // nop
+	};
+
+	std::memcpy(&code[2], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xb8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0
+		0xff, 0xe0,                    // jmp eax
+		0x90,                          // nop
+		0x90,                          // nop
+		0x90,                          // nop
+	};
+
+	std::memcpy(&code[1], &handler, 4);
+#endif
+
+	switch (gameBuild)
+	{
+#ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCryAction, 0x2180, &code, sizeof(code));
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryAction, 0x4110, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryAction, 0x3e60, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		{
+			FillMem(pCryAction, 0x3f40, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		{
+			FillMem(pCryAction, 0x4230, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryAction, 0x40c0, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryAction, 0x44f0, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		{
+			FillMem(pCryAction, 0x42a0, &code, sizeof(code));
+			break;
+		}
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryAction, 0x40b0, &code, sizeof(code));
+			break;
+		}
+#else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryAction, 0xd470, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryAction, 0xd920, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		{
+			FillMem(pCryAction, 0xdcc0, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		{
+			FillMem(pCryAction, 0xd9c0, &code, sizeof(code));
+			break;
+		}
+		case 6527:
+		{
+			FillMem(pCryAction, 0xe0d0, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryAction, 0xdee0, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryAction, 0xe0d0, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		{
+			FillMem(pCryAction, 0xe050, &code, sizeof(code));
+			break;
+		}
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryAction, 0xdf50, &code, sizeof(code));
+			break;
+		}
+#endif
+	}
+}
+
+/**
+ * Used to fix the CryWarning format string vulnerability.
+ */
+void MemoryPatch::CryAction::HookCryWarning(void* pCryAction, int gameBuild,
+	void (*handler)(int, int, const char* format, ...))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0
+		0xff, 0xe0,                                                  // jmp rax
+	};
+
+	std::memcpy(&code[2], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xb8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0
+		0xff, 0xe0,                    // jmp eax
+		0x90,                          // nop
+		0x90,                          // nop
+		0x90,                          // nop
+	};
+
+	std::memcpy(&code[1], &handler, 4);
+#endif
+
+	switch (gameBuild)
+	{
+#ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCryAction, 0x1d60, &code, sizeof(code));
+			break;
+		}
+		case 5767:
+		case 5879:
+		case 6115:
+		case 6156:
+		case 6566:
+		case 6586:
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryAction, 0x1000, &code, sizeof(code));
+			break;
+		}
+#else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
+		case 5767:
+		case 5879:
+		case 6115:
+		case 6156:
+		case 6527:
+		case 6566:
+		case 6586:
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryAction, 0x3240, &code, sizeof(code));
+			break;
+		}
+#endif
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CryGame
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Used to fix the GameWarning format string vulnerability.
+ */
+void MemoryPatch::CryGame::HookGameWarning(void* pCryGame, int gameBuild, void (*handler)(const char* format, ...))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0
+		0xff, 0xe0,                                                  // jmp rax
+		0x90,                                                        // nop
+		0x90,                                                        // nop
+		0x90,                                                        // nop
+	};
+
+	std::memcpy(&code[2], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xb8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0
+		0xff, 0xe0,                    // jmp eax
+		0x90,                          // nop
+		0x90,                          // nop
+		0x90,                          // nop
+	};
+
+	std::memcpy(&code[1], &handler, 4);
+#endif
+
+	switch (gameBuild)
+	{
+#ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCryGame, 0x2180, &code, sizeof(code));
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryGame, 0x6b40, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryGame, 0x69e0, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		{
+			FillMem(pCryGame, 0x7620, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		{
+			FillMem(pCryGame, 0x7ef0, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryGame, 0x84e0, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryGame, 0x7aa0, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		{
+			FillMem(pCryGame, 0x7a60, &code, sizeof(code));
+			break;
+		}
+		case 6670:
+		{
+			FillMem(pCryGame, 0x7a80, &code, sizeof(code));
+			break;
+		}
+		case 6729:
+		{
+			FillMem(pCryGame, 0x7a90, &code, sizeof(code));
+			break;
+		}
+#else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryGame, 0x33040, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryGame, 0x330e0, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		{
+			FillMem(pCryGame, 0x33cc0, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		{
+			FillMem(pCryGame, 0x33be0, &code, sizeof(code));
+			break;
+		}
+		case 6527:
+		{
+			FillMem(pCryGame, 0x33f40, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryGame, 0x338e0, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryGame, 0x33e50, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		{
+			FillMem(pCryGame, 0x33ea0, &code, sizeof(code));
+			break;
+		}
+		case 6670:
+		{
+			FillMem(pCryGame, 0x33f70, &code, sizeof(code));
+			break;
+		}
+		case 6729:
+		{
+			FillMem(pCryGame, 0x33f60, &code, sizeof(code));
+			break;
+		}
+#endif
+	}
+}
+
+/**
+ * Used to fix the CryWarning format string vulnerability.
+ */
+void MemoryPatch::CryGame::HookCryWarning(void* pCryGame, int gameBuild,
+	void (*handler)(int, int, const char* format, ...))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0
+		0xff, 0xe0,                                                  // jmp rax
+	};
+
+	std::memcpy(&code[2], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xb8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0
+		0xff, 0xe0,                    // jmp eax
+		0x90,                          // nop
+		0x90,                          // nop
+		0x90,                          // nop
+	};
+
+	std::memcpy(&code[1], &handler, 4);
+#endif
+
+	switch (gameBuild)
+	{
+#ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			FillMem(pCryGame, 0x1d60, &code, sizeof(code));
+			break;
+		}
+		case 5767:
+		case 5879:
+		case 6115:
+		{
+			FillMem(pCryGame, 0x11f0, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		case 6566:
+		case 6586:
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryGame, 0x1200, &code, sizeof(code));
+			break;
+		}
+#else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryGame, 0x24060, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryGame, 0x24080, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		case 6156:
+		{
+			FillMem(pCryGame, 0x247a0, &code, sizeof(code));
+			break;
+		}
+		case 6527:
+		{
+			FillMem(pCryGame, 0x247c0, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryGame, 0x24770, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryGame, 0x24760, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryGame, 0x247a0, &code, sizeof(code));
+			break;
+		}
+#endif
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CryNetwork
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Used to fix the CryWarning format string vulnerability.
+ */
+void MemoryPatch::CryNetwork::HookCryWarning(void* pCryNetwork, int gameBuild,
+	void (*handler)(int, int, const char* format, ...))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0
+		0xff, 0xe0,                                                  // jmp rax
+	};
+
+	std::memcpy(&code[2], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xb8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0
+		0xff, 0xe0,                    // jmp eax
+		0x90,                          // nop
+	};
+
+	std::memcpy(&code[1], &handler, 4);
+#endif
+
+	switch (gameBuild)
+	{
+#ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		{
+			// Crysis Warhead has no CryWarning in its CryNetwork
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryNetwork, 0x24c00, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryNetwork, 0x24f40, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		{
+			FillMem(pCryNetwork, 0x24b40, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		{
+			FillMem(pCryNetwork, 0x24490, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryNetwork, 0x23fa0, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryNetwork, 0x24dc0, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryNetwork, 0x24f70, &code, sizeof(code));
+			break;
+		}
+#else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
+		case 5767:
+		{
+			FillMem(pCryNetwork, 0xcc85, &code, sizeof(code));
+			break;
+		}
+		case 5879:
+		{
+			FillMem(pCryNetwork, 0xcb51, &code, sizeof(code));
+			break;
+		}
+		case 6115:
+		{
+			FillMem(pCryNetwork, 0xcc2b, &code, sizeof(code));
+			break;
+		}
+		case 6156:
+		{
+			FillMem(pCryNetwork, 0xcba2, &code, sizeof(code));
+			break;
+		}
+		case 6527:
+		{
+			FillMem(pCryNetwork, 0xcd3a, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCryNetwork, 0xd2bc, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		{
+			FillMem(pCryNetwork, 0xca3c, &code, sizeof(code));
+			break;
+		}
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCryNetwork, 0xce18, &code, sizeof(code));
+			break;
+		}
+#endif
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CrySystem
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Used to fix the CryWarning format string vulnerability.
+ */
+void MemoryPatch::CrySystem::HookCryWarning(void* pCrySystem, int gameBuild,
+	void (*handler)(int, int, const char* format, ...))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0
+		0xff, 0xe0,                                                  // jmp rax
+	};
+
+	std::memcpy(&code[2], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xb8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0
+		0xff, 0xe0,                    // jmp eax
+		0x90,                          // nop
+		0x90,                          // nop
+		0x90,                          // nop
+	};
+
+	std::memcpy(&code[1], &handler, 4);
+#endif
+
+	switch (gameBuild)
+	{
+#ifdef BUILD_64BIT
+		case 710:
+		case 711:
+		case 5767:
+		case 5879:
+		case 6115:
+		case 6156:
+		{
+			FillMem(pCrySystem, 0x16e0, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCrySystem, 0x1770, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCrySystem, 0x16e0, &code, sizeof(code));
+			break;
+		}
+#else
+		case 687:
+		case 710:
+		case 711:
+		{
+			// TODO: 32-bit Crysis Warhead
+			break;
+		}
+		case 5767:
+		case 5879:
+		case 6115:
+		case 6156:
+		case 6527:
+		{
+			FillMem(pCrySystem, 0x3980, &code, sizeof(code));
+			break;
+		}
+		case 6566:
+		{
+			FillMem(pCrySystem, 0x3a20, &code, sizeof(code));
+			break;
+		}
+		case 6586:
+		case 6627:
+		case 6670:
+		case 6729:
+		{
+			FillMem(pCrySystem, 0x3980, &code, sizeof(code));
 			break;
 		}
 #endif

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -13,6 +13,9 @@ namespace MemoryPatch
 	{
 		void AllowDX9ImmersiveMultiplayer(void* pCryAction, int gameBuild);
 		void DisableGameplayStats(void* pCryAction, int gameBuild);
+		void HookGameWarning(void* pCryAction, int gameBuild, void (*handler)(const char* format, ...));
+		void HookCryWarning(void* pCryAction, int gameBuild,
+			void (*handler)(int, int, const char* format, ...));
 	}
 
 	namespace CryGame
@@ -20,6 +23,9 @@ namespace MemoryPatch
 		void DisableIntros(void* pCryGame, int gameBuild);
 		void CanJoinDX10Servers(void* pCryGame, int gameBuild);
 		void EnableDX10Menu(void* pCryGame, int gameBuild);
+		void HookGameWarning(void* pCryGame, int gameBuild, void (*handler)(const char* format, ...));
+		void HookCryWarning(void* pCryGame, int gameBuild,
+			void (*handler)(int, int, const char* format, ...));
 	}
 
 	namespace CryNetwork
@@ -29,6 +35,8 @@ namespace MemoryPatch
 		void FixInternetConnect(void* pCryNetwork, int gameBuild);
 		void FixFileCheckCrash(void* pCryNetwork, int gameBuild);
 		void DisableServerProfile(void* pCryNetwork, int gameBuild);
+		void HookCryWarning(void* pCryNetwork, int gameBuild,
+			void (*handler)(int, int, const char* format, ...));
 	}
 
 	namespace CrySystem
@@ -44,6 +52,8 @@ namespace MemoryPatch
 			void (*handler)(const char* defaultLanguage, ILocalizationManager* pLocalizationManager));
 		void HookChangeUserPath(void* pCrySystem, int gameBuild,
 			void (*handler)(ISystem* pSystem, const char* userPath));
+		void HookCryWarning(void* pCrySystem, int gameBuild,
+			void (*handler)(int, int, const char* format, ...));
 	}
 
 	namespace CryRenderD3D9
@@ -64,6 +74,7 @@ namespace MemoryPatch
 		};
 
 		void HookAdapterInfo(void* pCryRenderD3D9, int gameBuild, void (*handler)(AdapterInfo* info));
+		void HookLogWarning(void* pCryRenderD3D9, int gameBuild, void (*handler)(const char* format, ...));
 	}
 
 	namespace CryRenderD3D10
@@ -103,6 +114,7 @@ namespace MemoryPatch
 		void FixLowRefreshRateBug(void* pCryRenderD3D10, int gameBuild);
 		void HookAdapterInfo(void* pCryRenderD3D10, int gameBuild, void (*handler)(AdapterInfo* info));
 		void HookInitAPI(void* pCryRenderD3D10, int gameBuild, bool (*handler)(SystemAPI* api));
+		void HookLogWarning(void* pCryRenderD3D10, int gameBuild, void (*handler)(const char* format, ...));
 	}
 
 	namespace CryRenderNULL

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -124,6 +124,12 @@ namespace MemoryPatch
 
 	namespace WarheadEXE
 	{
+		using CryAction::AllowDX9ImmersiveMultiplayer;
+		using CryAction::DisableGameplayStats;
+		using CryAction::HookCryWarning;
+		using CryAction::HookGameWarning;
+		using CryGame::DisableIntros;
+
 		void FixHInstance(void* pEXE, int gameBuild);
 	}
 

--- a/Code/Library/StringFormat.cpp
+++ b/Code/Library/StringFormat.cpp
@@ -92,6 +92,32 @@ void StringFormatToV(std::string& result, const char* format, va_list args)
 	va_end(argsCopy);
 }
 
+void StringFormatToBuffer(char* buffer, std::size_t bufferSize, const char* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	StringFormatToBufferV(buffer, bufferSize, format, args);
+	va_end(args);
+}
+
+void StringFormatToBufferV(char* buffer, std::size_t bufferSize, const char* format, va_list args)
+{
+	int status = _vsnprintf(buffer, bufferSize, format, args);
+
+	// make sure the buffer is always null-terminated
+	if (bufferSize > 0)
+	{
+		if (status < 0)
+		{
+			buffer[0] = '\0';
+		}
+		else if (static_cast<std::size_t>(status) >= bufferSize)
+		{
+			buffer[bufferSize - 1] = '\0';
+		}
+	}
+}
+
 std::runtime_error StringFormat_Error(const char* format, ...)
 {
 	va_list args;

--- a/Code/Library/StringFormat.h
+++ b/Code/Library/StringFormat.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdarg>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
 
@@ -9,6 +10,9 @@ std::string StringFormatV(const char* format, va_list args);
 
 void StringFormatTo(std::string& result, const char* format, ...);
 void StringFormatToV(std::string& result, const char* format, va_list args);
+
+void StringFormatToBuffer(char* buffer, std::size_t bufferSize, const char* format, ...);
+void StringFormatToBufferV(char* buffer, std::size_t bufferSize, const char* format, va_list args);
 
 std::runtime_error StringFormat_Error(const char* format, ...);
 

--- a/Tools/disassembler.py
+++ b/Tools/disassembler.py
@@ -1,0 +1,122 @@
+from iced_x86 import Decoder, Code, Instruction
+from pefile import PE, MACHINE_TYPE
+
+def get_bits(pe: PE) -> int:
+    if pe.FILE_HEADER.Machine == MACHINE_TYPE['IMAGE_FILE_MACHINE_I386']:
+        return 32
+    if pe.FILE_HEADER.Machine == MACHINE_TYPE['IMAGE_FILE_MACHINE_AMD64']:
+        return 64
+    assert False, 'Only x86 is supported'
+
+def get_text_section_data_and_ip(pe: PE) -> tuple[bytes, int]:
+    pe_base = pe.OPTIONAL_HEADER.ImageBase
+    for section in pe.sections:
+        if section.Name == b'.text\x00\x00\x00':
+            return section.get_data(ignore_padding=True), pe_base + section.VirtualAddress
+    assert False, 'Cannot find .text section'
+
+def disassemble(pe: PE) -> list[Instruction]:
+    text_data, text_ip = get_text_section_data_and_ip(pe)
+    return list(Decoder(bitness=get_bits(pe), data=text_data, ip=text_ip))
+
+class XRefs:
+    def __init__(self):
+        self.rvas: dict[int, list[int]] = {}
+        self.count = 0
+
+def find_xrefs(pe: PE, instructions: list[Instruction]) -> XRefs:
+    xrefs = XRefs()
+    pe_base = pe.OPTIONAL_HEADER.ImageBase
+    pe_end = pe_base + pe.OPTIONAL_HEADER.SizeOfImage
+    for index, instruction in enumerate(instructions):
+        displacement = instruction.memory_displacement
+        if pe_base <= displacement < pe_end:
+            rva = displacement - pe_base
+            if rva not in xrefs.rvas:
+                xrefs.rvas[rva] = []
+            xrefs.rvas[rva].append(index)
+            xrefs.count += 1
+    return xrefs
+
+class Disassembler:
+    def __init__(self, pe: PE):
+        self.pe = pe
+        self.pe_base = int(pe.OPTIONAL_HEADER.ImageBase)
+        self.pe_end = int(self.pe_base + pe.OPTIONAL_HEADER.SizeOfImage)
+        self.x64 = bool(pe.FILE_HEADER.Machine == MACHINE_TYPE['IMAGE_FILE_MACHINE_AMD64'])
+        self.instructions = disassemble(pe)
+        self.xrefs = find_xrefs(pe, self.instructions)
+
+    def dump_xrefs(self):
+        for rva, indexes in self.xrefs.rvas.items():
+            for index in indexes:
+                print(f'{self.instruction_to_string(index)} -> 0x{rva:x}')
+
+    def instruction_to_rva(self, index: int) -> int:
+        return self.instructions[index].ip - self.pe_base
+
+    def instruction_to_string(self, index: int) -> str:
+        instruction = self.instructions[index]
+        return f'{instruction.ip:016X} {instruction:XrsSMi}'
+
+    def has_call_xref(self, index: int) -> bool:
+        rva = self.instruction_to_rva(index)
+        if rva not in self.xrefs.rvas:
+            return False
+        call_code = Code.CALL_REL32_64 if self.x64 else Code.CALL_REL32_32
+        for x in self.xrefs.rvas[rva]:
+            instruction = self.instructions[x]
+            if instruction.code == call_code:
+                return True
+        return False
+
+    def has_ret_before(self, index: int) -> bool:
+        if index == 0:
+            return False
+        ret_code = Code.RETNQ if self.x64 else Code.RETND
+        return self.instructions[index - 1].code == ret_code
+
+    def has_call_after(self, index: int) -> bool:
+        if (index + 1) >= len(self.instructions):
+            return False
+        call_code = Code.CALL_REL32_64 if self.x64 else Code.CALL_REL32_32
+        return self.instructions[index + 1].code == call_code
+
+class Subroutine:
+    def __init__(self, disasm: Disassembler, begin_index: int, end_index: int):
+        self.disasm = disasm
+        self.begin_index = begin_index
+        self.end_index = end_index
+
+    @classmethod
+    def from_instruction(cls, disasm: Disassembler, index: int):
+        begin_index = index
+        while begin_index > 0:
+            if disasm.has_call_xref(begin_index):
+                break
+            prev_index = begin_index - 1
+            prev_instruction = disasm.instructions[prev_index]
+            if prev_instruction.code == Code.INT3:
+                break
+            begin_index -= 1
+        end_index = index + 1
+        while end_index < len(disasm.instructions):
+            if disasm.has_call_xref(end_index):
+                break
+            next_instruction = disasm.instructions[end_index]
+            if next_instruction.code == Code.INT3:
+                break
+            end_index += 1
+        return cls(disasm, begin_index, end_index)
+
+    @property
+    def rva(self) -> int:
+        return self.disasm.instruction_to_rva(self.begin_index)
+
+    @property
+    def instructions(self) -> list[Instruction]:
+        return self.disasm.instructions[self.begin_index:self.end_index]
+
+    def dump(self):
+        for index in range(self.begin_index, self.end_index):
+            print(self.disasm.instruction_to_string(index))

--- a/Tools/memory_patch_generator.py
+++ b/Tools/memory_patch_generator.py
@@ -1,0 +1,491 @@
+from enum import StrEnum
+from hashlib import sha256
+from pathlib import Path
+
+from iced_x86 import Code, Encoder, Instruction, MemoryOperand, Register
+from pefile import PE
+
+from checksums import CRY_CHECKSUMS
+from disassembler import Disassembler, Subroutine
+
+CRYSIS_BUILDS = (5767, 5879, 6115, 6156)
+CRYSIS_WARS_64BIT_BUILDS = (6566, 6586, 6627, 6670, 6729)
+CRYSIS_WARS_32BIT_BUILDS = (6527,) + CRYSIS_WARS_64BIT_BUILDS
+CRYSIS_WARS_BUILDS = CRYSIS_WARS_32BIT_BUILDS
+CRYSIS_WARHEAD_64BIT_BUILDS = (710, 711)
+CRYSIS_WARHEAD_32BIT_BUILDS = (687,) + CRYSIS_WARHEAD_64BIT_BUILDS
+CRYSIS_WARHEAD_BUILDS = CRYSIS_WARHEAD_32BIT_BUILDS
+
+class Subsystem(StrEnum):
+    Cry3DEngine = 'Cry3DEngine.dll'
+    CryAISystem = 'CryAISystem.dll'
+    CryAction = 'CryAction.dll'
+    CryAnimation = 'CryAnimation.dll'
+    CryEntitySystem = 'CryEntitySystem.dll'
+    CryFont = 'CryFont.dll'
+    CryGame = 'CryGame.dll'
+    CryInput = 'CryInput.dll'
+    CryMovie = 'CryMovie.dll'
+    CryNetwork = 'CryNetwork.dll'
+    CryPhysics = 'CryPhysics.dll'
+    CryRenderD3D10 = 'CryRenderD3D10.dll'
+    CryRenderD3D9 = 'CryRenderD3D9.dll'
+    CryRenderNULL = 'CryRenderNULL.dll'
+    CryScriptSystem = 'CryScriptSystem.dll'
+    CrySoundSystem = 'CrySoundSystem.dll'
+    CrySystem = 'CrySystem.dll'
+
+class CryDll:
+    def __init__(self, path: Path, subsystem: Subsystem, pe: PE, build: int, disasm: Disassembler):
+        self.path = path
+        self.subsystem = subsystem
+        self.pe = pe
+        self.build = build
+        self.disasm = disasm
+
+    @property
+    def x64(self) -> bool:
+        return self.disasm.x64
+
+    @property
+    def bits(self) -> int:
+        return 64 if self.x64 else 32
+
+    @property
+    def is_og(self) -> bool:
+        return self.build in CRYSIS_BUILDS
+
+    @property
+    def is_wars(self) -> bool:
+        return self.build in CRYSIS_WARS_BUILDS
+
+    @property
+    def is_warhead(self) -> bool:
+        return self.build in CRYSIS_WARHEAD_BUILDS
+
+def get_build_dir(build: int) -> str:
+    if build in CRYSIS_BUILDS:
+        return f'Crysis_{build}'
+    if build in CRYSIS_WARS_BUILDS:
+        return f'Crysis_Wars_{build}'
+    if build in CRYSIS_WARHEAD_BUILDS:
+        return f'Crysis_Warhead_{build}'
+    assert False, f'Unknown build {build}'
+
+def get_dll_path(subsystem: Subsystem, build: int, x64: bool) -> Path:
+    base_path = Path(__file__).with_name('DLLs')
+    build_dir = get_build_dir(build)
+    bin_dir = 'Bin64' if x64 else 'Bin32'
+    filename = subsystem.value
+    if build in CRYSIS_WARHEAD_BUILDS and subsystem in (Subsystem.CryAction, Subsystem.CryGame):
+        filename = 'Crysis64.exe'
+    return base_path / build_dir / bin_dir / filename
+
+def get_real_dll_build(dll: CryDll) -> int:
+    build = dll.pe.VS_FIXEDFILEINFO[0].ProductVersionLS & 0xffff
+    if build == 1 and dll.subsystem is Subsystem.CryRenderD3D10:
+        build = 5767
+    return build
+
+def verify_dll_checksum(dll: CryDll):
+    build = dll.build
+    bits = dll.bits
+    name = dll.path.name
+    checksum = sha256(dll.path.read_bytes()).hexdigest()
+    assert build in CRY_CHECKSUMS, f'Unknown build {build} of {dll.path}'
+    assert bits in CRY_CHECKSUMS[build], f'Unknown {bits}-bit variant of {dll.path}'
+    assert name in CRY_CHECKSUMS[build][bits], f'Unknown name "{name}" of {dll.path}'
+    assert checksum == CRY_CHECKSUMS[build][bits][name], f'Invalid checksum of {dll.path}'
+
+def load_dll(subsystem: Subsystem, build: int, x64: bool) -> CryDll:
+    path = get_dll_path(subsystem, build, x64)
+    print(f'Loading {path}')
+    pe = PE(path)
+    disasm = Disassembler(pe)
+    dll = CryDll(path, subsystem, pe, build, disasm)
+    assert dll.x64 == x64
+    assert get_real_dll_build(dll) == build
+    verify_dll_checksum(dll)
+    return dll
+
+class Context:
+    def __init__(self, subsystem: Subsystem, dlls: list[CryDll]):
+        self.subsystem = subsystem
+        self.dlls = dlls
+
+    @classmethod
+    def load(cls, subsystem: Subsystem, full: bool):
+        dlls = []
+        if full:
+            # 32-bit Crysis Warhead is not supported
+            for build in CRYSIS_BUILDS + CRYSIS_WARS_32BIT_BUILDS:
+                dlls.append(load_dll(subsystem, build, x64=False))
+            for build in CRYSIS_BUILDS + CRYSIS_WARS_64BIT_BUILDS + CRYSIS_WARHEAD_64BIT_BUILDS:
+                dlls.append(load_dll(subsystem, build, x64=True))
+        else:
+            dlls.append(load_dll(subsystem, build=6156, x64=False))
+            dlls.append(load_dll(subsystem, build=6156, x64=True))
+        return cls(subsystem, dlls)
+
+class Assembly:
+    def __init__(self, x64: bool):
+        self.encoder = Encoder(64 if x64 else 32)
+        self.instructions: list[Instruction] = []
+        self.machine_code: list[bytes] = []
+        self.code_size = 0
+
+    def add(self, instruction: Instruction):
+        self.instructions.append(instruction)
+        self.code_size += self.encoder.encode(instruction, rip=0)
+        self.machine_code.append(self.encoder.take_buffer())
+
+class CodeGenerator:
+    INDENT = '\t'
+    MAX_LINE_LENGTH = 120
+
+    def __init__(self):
+        self.indent_level = 0
+        self.lines: list[str] = []
+
+    def add(self, line: str, *, no_indent = False):
+        line = (self.INDENT * self.indent_level * (not no_indent)) + line if line else ''
+        assert len(line) <= self.MAX_LINE_LENGTH, f'Too long line: "{line}"'
+        self.lines.append(line)
+
+    def begin_block(self, line = '{'):
+        self.add(line)
+        self.indent_level += 1
+
+    def end_block(self, line = '}'):
+        self.indent_level -= 1
+        self.add(line)
+
+    def begin_function(self, ret_type: str, name: str, params: list[str]):
+        line = f'{ret_type} {name}('
+        for index, param in enumerate(params):
+            if len(line + param) > (self.MAX_LINE_LENGTH - 3):
+                self.add(line + (',' if index > 0 else ''))
+                line = ''
+            if index > 0 and line:
+                line += ', '
+            if not line:
+                line += self.INDENT
+            line += param
+        self.add(line + ')')
+        self.begin_block()
+
+    def end_function(self):
+        self.end_block()
+
+    def add_doc_comment(self, comment: str):
+        self.add('/**')
+        if comment:
+            lines = comment.splitlines()
+            # remove trailing empty line
+            if not lines[-1].strip():
+                lines.pop()
+            for line in lines:
+                self.add(f' * {line.lstrip()}'.rstrip())
+        self.add(' */')
+
+    def add_build_switch_cases(self, cases: dict[int, list[str]]):
+        builds = list(cases)
+        builds.sort()
+        for i, build in enumerate(builds):
+            self.add(f'case {build}:')
+            if (i + 1) < len(builds) and cases[build] == cases[builds[i + 1]]:
+                # merge identical adjacent cases
+                continue
+            self.begin_block()
+            for line in cases[build]:
+                self.add(line)
+                self.add('break;')
+            self.end_block()
+
+    def add_assembly_as_c_array(self, assembly: Assembly, name: str, const: bool):
+        max_length = max(len(data) for data in assembly.machine_code)
+        self.begin_block(('const ' if const else '') + f'unsigned char {name}[] = ' + '{')
+        for instruction, data in zip(assembly.instructions, assembly.machine_code):
+            line = ''.join(f'0x{byte:02x}, ' for byte in data)
+            line += ' ' * ((max_length - len(data)) * 6)
+            line += f' // {instruction:xrsSMi}'
+            self.add(line)
+        self.end_block('};')
+
+class DllSubroutine:
+    def __init__(self, dll: CryDll, subroutine: Subroutine):
+        self.dll = dll
+        self.subroutine = subroutine
+
+class MemoryPatch:
+    def __init__(self, subsystem: Subsystem, name: str):
+        self.subsystem = subsystem
+        self.name = name
+        self.additional_params: list[str] = []
+        self.build_switch_cases_32bit: dict[int, list[str]] = {}
+        self.build_switch_cases_64bit: dict[int, list[str]] = {}
+        self.jmp_hook_targets: list[DllSubroutine] = []
+
+    def generate(self, gen: CodeGenerator):
+        func_name = f'MemoryPatch::{self.subsystem.name}::{self.name}'
+        func_params = [f'void* p{self.subsystem.name}', 'int gameBuild'] + self.additional_params
+        gen.begin_function('void', func_name, func_params)
+        if self.jmp_hook_targets:
+            self._generate_jmp_hook(gen)
+        if len(self.build_switch_cases_32bit) > 1:
+            # 32-bit Crysis Warhead is not supported
+            for build in CRYSIS_WARHEAD_32BIT_BUILDS:
+                assert build not in self.build_switch_cases_32bit
+                self.build_switch_cases_32bit[build] = ['// TODO: 32-bit Crysis Warhead']
+        gen.add('switch (gameBuild)')
+        gen.begin_block()
+        gen.add('#ifdef BUILD_64BIT', no_indent=True)
+        gen.add_build_switch_cases(self.build_switch_cases_64bit)
+        gen.add('#else', no_indent=True)
+        gen.add_build_switch_cases(self.build_switch_cases_32bit)
+        gen.add('#endif', no_indent=True)
+        gen.end_block()
+        gen.end_function()
+
+    def _generate_jmp_hook(self, gen: CodeGenerator):
+        gen.add('#ifdef BUILD_64BIT', no_indent=True)
+        gen.add_assembly_as_c_array(self._get_jmp_hook_code(x64=True), 'code', const=False)
+        gen.add('')
+        gen.add('std::memcpy(&code[2], &handler, 8);')
+        gen.add('#else', no_indent=True)
+        gen.add_assembly_as_c_array(self._get_jmp_hook_code(x64=False), 'code', const=False)
+        gen.add('')
+        gen.add('std::memcpy(&code[1], &handler, 4);')
+        gen.add('#endif', no_indent=True)
+        gen.add('')
+        for target in self.jmp_hook_targets:
+            cases = self.build_switch_cases_64bit if target.dll.x64 else self.build_switch_cases_32bit
+            build = target.dll.build
+            if build not in cases:
+                cases[build] = []
+            cases[build].append(f'FillMem(p{self.subsystem.name}, 0x{target.subroutine.rva:x}, &code, sizeof(code));')
+
+    def _get_jmp_hook_code(self, x64: bool) -> Assembly:
+        assembly = Assembly(x64)
+        if x64:
+            assembly.add(Instruction.create_reg_u64(Code.MOV_R64_IMM64, Register.RAX, 0))
+            assembly.add(Instruction.create_reg(Code.JMP_RM64, Register.RAX))
+        else:
+            assembly.add(Instruction.create_reg_u32(Code.MOV_R32_IMM32, Register.EAX, 0))
+            assembly.add(Instruction.create_reg(Code.JMP_RM32, Register.EAX))
+        # be nice to disassemblers and avoid any leftovers from the original instructions
+        ideal_size = self._get_ideal_jmp_hook_size(required_size=assembly.code_size, x64=x64)
+        # pad with nops if needed
+        nop = Instruction.create(Code.NOPD)
+        while assembly.code_size < ideal_size:
+            assembly.add(nop)
+        return assembly
+
+    def _get_ideal_jmp_hook_size(self, required_size: int, x64: bool) -> int:
+        ideal_size = 0
+        for target in self.jmp_hook_targets:
+            if target.dll.x64 != x64:
+                continue
+            size = 0
+            for instruction in target.subroutine.instructions:
+                assert len(instruction) != 0
+                size += len(instruction)
+                if size >= required_size:
+                    break
+            assert size >= required_size, 'Target subroutine is too small'
+            if ideal_size == 0:
+                ideal_size = size
+            assert size == ideal_size, 'Target subroutine is not the same in all builds'
+        return ideal_size
+
+class HookGameWarning:
+    '''Used to fix the GameWarning format string vulnerability.'''
+
+    def _find_game_warning_32(self, dll: CryDll) -> Subroutine:
+        assert not dll.x64
+        found = []
+        first_expected = Instruction.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x1000)
+        for first_index, first in enumerate(dll.disasm.instructions):
+            if first != first_expected:
+                continue
+            sub = Subroutine.from_instruction(dll.disasm, first_index)
+            if first_index != sub.begin_index or len(sub.instructions) < 14:
+                continue
+            if sub.instructions[1].code != Code.CALL_REL32_32:
+                continue
+            if sub.instructions[2].code != Code.MOV_R32_RM32 or sub.instructions[2].op0_register != Register.EAX:
+                continue
+            if sub.instructions[3] != Instruction.create_reg_reg(Code.TEST_RM32_R32, Register.EAX, Register.EAX):
+                continue
+            current = sub.instructions[4]
+            if current.code != Code.JE_REL8_32 or current.near_branch_target != sub.instructions[-2].ip:
+                continue
+            found.append(sub)
+        assert len(found) == 1
+        return found[0]
+
+    def _find_game_warning_64(self, dll: CryDll) -> Subroutine:
+        assert dll.x64
+        found = []
+        first_expected = Instruction.create_reg_reg(Code.TEST_RM64_R64, Register.RCX, Register.RCX)
+        for first_index, first in enumerate(dll.disasm.instructions):
+            if first != first_expected:
+                continue
+            sub = Subroutine.from_instruction(dll.disasm, first_index)
+            if first_index != sub.begin_index or len(sub.instructions) < 16:
+                continue
+            current = sub.instructions[1]
+            if current.code != Code.JE_REL8_64 or current.near_branch_target != sub.instructions[-1].ip:
+                continue
+            if sub.instructions[2].code != Code.MOV_RM64_R64 or sub.instructions[2].op1_register != Register.RCX:
+                continue
+            if sub.instructions[3].code != Code.MOV_RM64_R64 or sub.instructions[3].op1_register != Register.RDX:
+                continue
+            if sub.instructions[4].code != Code.MOV_RM64_R64 or sub.instructions[4].op1_register != Register.R8:
+                continue
+            if sub.instructions[5].code != Code.MOV_RM64_R64 or sub.instructions[5].op1_register != Register.R9:
+                continue
+            if sub.instructions[6].code != Code.MOV_R32_IMM32 or sub.instructions[6].op0_register != Register.EAX:
+                continue
+            if sub.instructions[7].code != Code.CALL_REL32_64:
+                continue
+            found.append(sub)
+        assert len(found) == 1
+        return found[0]
+
+    def generate(self, context: Context, gen: CodeGenerator):
+        patch = MemoryPatch(context.subsystem, self.__class__.__name__)
+        patch.additional_params.append('void (*handler)(const char* format, ...)')
+        for dll in context.dlls:
+            subroutine = self._find_game_warning_64(dll) if dll.x64 else self._find_game_warning_32(dll)
+            patch.jmp_hook_targets.append(DllSubroutine(dll, subroutine))
+        patch.generate(gen)
+
+class HookCryWarning:
+    '''Used to fix the CryWarning format string vulnerability.'''
+
+    def _find_cry_warning_32(self, dll: CryDll) -> Subroutine:
+        assert not dll.x64
+        found = []
+        first_expected = Instruction.create_reg_u32(Code.MOV_R32_IMM32, Register.EAX, 0x1000)
+        for first_index, first in enumerate(dll.disasm.instructions):
+            if first != first_expected:
+                continue
+            sub = Subroutine.from_instruction(dll.disasm, first_index)
+            if first_index not in (sub.begin_index, sub.begin_index + 2) or len(sub.instructions) < 30:
+                continue
+            instructions = sub.instructions
+            if first_index == sub.begin_index + 2:
+                # ignore optional prologue
+                instructions = instructions[2:]
+            if instructions[1].code != Code.CALL_REL32_32:
+                continue
+            # skip index 2
+            if instructions[3] != Instruction.create_reg_reg(Code.TEST_RM32_R32, Register.EAX, Register.EAX):
+                continue
+            if instructions[4].code != Code.JE_REL8_32 or instructions[4].near_branch_target != instructions[-2].ip:
+                continue
+            if instructions[5] != Instruction.create_mem_u32(Code.CMP_RM32_IMM8, MemoryOperand(Register.EAX), 0x0):
+                continue
+            if instructions[6].code != Code.JE_REL8_32 or instructions[6].near_branch_target != instructions[-2].ip:
+                continue
+            found.append(sub)
+        assert len(found) == 1
+        return found[0]
+
+    def _find_cry_warning_64(self, dll: CryDll) -> Subroutine:
+        assert dll.x64
+        found = []
+        expected = [
+            Instruction.create_mem_reg(Code.MOV_RM64_R64,
+                MemoryOperand(base=Register.RSP, displ=0x18, displ_size=0x1), Register.R8),
+            Instruction.create_mem_reg(Code.MOV_RM64_R64,
+                MemoryOperand(base=Register.RSP, displ=0x20, displ_size=0x1), Register.R9),
+            Instruction.create_reg(Code.PUSH_R64, Register.RBX),
+            Instruction.create_reg(Code.PUSH_R64, Register.RDI),
+            Instruction.create_reg_u32(Code.MOV_R32_IMM32, Register.EAX, 0x1038),
+        ]
+        for first_index, first in enumerate(dll.disasm.instructions):
+            if first != expected[0]:
+                continue
+            sub = Subroutine.from_instruction(dll.disasm, first_index)
+            if first_index != sub.begin_index or len(sub.instructions) < 32:
+                continue
+            if expected[1:] != sub.instructions[1:5]:
+                continue
+            if sub.instructions[5].code != Code.CALL_REL32_64:
+                continue
+            if sub.instructions[6] != Instruction.create_reg_reg(Code.SUB_R64_RM64, Register.RSP, Register.RAX):
+                continue
+            found.append(sub)
+        assert len(found) == 1
+        return found[0]
+
+    def generate(self, context: Context, gen: CodeGenerator):
+        patch = MemoryPatch(context.subsystem, self.__class__.__name__)
+        patch.additional_params.append('void (*handler)(int, int, const char* format, ...)')
+        for dll in context.dlls:
+            if dll.x64 and dll.build in CRYSIS_WARHEAD_BUILDS and context.subsystem is Subsystem.CryNetwork:
+                patch.build_switch_cases_64bit[dll.build] = ['// Crysis Warhead has no CryWarning in its CryNetwork']
+                continue
+            subroutine = self._find_cry_warning_64(dll) if dll.x64 else self._find_cry_warning_32(dll)
+            patch.jmp_hook_targets.append(DllSubroutine(dll, subroutine))
+        patch.generate(gen)
+
+PATCHES = {
+    Subsystem.CryAction: [
+        HookGameWarning(),
+        HookCryWarning(),
+    ],
+    Subsystem.CryGame: [
+        HookGameWarning(),
+        HookCryWarning(),
+    ],
+    Subsystem.CryNetwork: [
+        HookCryWarning(),
+    ],
+    Subsystem.CrySystem: [
+        HookCryWarning(),
+    ],
+}
+
+TARGET_PATH = Path(__file__).parent / '..' / 'Code' / 'Launcher' / 'MemoryPatch.cpp'
+TARGET_MARKER = '// GENERATED MEMORY PATCHES'
+
+class MemoryPatchGenerator:
+    def __init__(self, full: bool):
+        self.gen = CodeGenerator()
+        self.full = full
+
+    def run(self):
+        self.gen.add('////////////////////////////////////////////////////////////////////////////////')
+        self.gen.add(TARGET_MARKER)
+        self.gen.add('////////////////////////////////////////////////////////////////////////////////')
+        self._generate_patches(Subsystem.CryAction)
+        self._generate_patches(Subsystem.CryGame)
+        self._generate_patches(Subsystem.CryNetwork)
+        self._generate_patches(Subsystem.CrySystem)
+        if self.full:
+            print('Writing...')
+            lines = TARGET_PATH.read_text(encoding='utf-8').splitlines()
+            lines = lines[:lines.index(TARGET_MARKER)]
+            lines.pop()
+            lines.extend(self.gen.lines)
+            TARGET_PATH.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+        else:
+            print('\n'.join(self.gen.lines))
+
+    def _generate_patches(self, subsystem: Subsystem):
+        self.gen.add('')
+        self.gen.add('////////////////////////////////////////////////////////////////////////////////')
+        self.gen.add(f'// {subsystem.name}')
+        self.gen.add('////////////////////////////////////////////////////////////////////////////////')
+        context = Context.load(subsystem, self.full)
+        for patch in PATCHES[subsystem]:
+            print(f'Generating {subsystem.name}::{patch.__class__.__name__}')
+            self.gen.add('')
+            self.gen.add_doc_comment(patch.__class__.__doc__)
+            patch.generate(context, self.gen)
+
+if __name__ == '__main__':
+    MemoryPatchGenerator(full=True).run()


### PR DESCRIPTION
Hook `CryWarning` and `GameWarning` to fix format string vulnerability in them. Hooks are automatically generated using the newly introduced memory patch generator. These are the very first automatically generated memory patches. Minor refactoring is also included.