### PR TITLE
Add real Windows build to the log + Fix OS::DLL::Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Notable changes in each release.
 
 ## [Unreleased]
+- Add real Windows version to the log. CrySystem cannot see beyond Windows 8 (6.2.9200).
 - Fix startup crash when `profile.xml` is corrupted ([#59](https://github.com/ccomrade/c1-launcher/pull/59)).
 - Fix startup crash of Warhead launcher when Logitech Gaming Software is installed
 ([#39](https://github.com/ccomrade/c1-launcher/issues/39)).

--- a/Code/Launcher/Editor/EditorLauncher.cpp
+++ b/Code/Launcher/Editor/EditorLauncher.cpp
@@ -30,13 +30,13 @@ static void OnVersionInit(MemoryPatch::Editor::Version* version)
 {
 	version->file_major = g_version.major;
 	version->file_minor = g_version.minor;
-	version->file_tweak = g_version.tweak;
 	version->file_patch = g_version.patch;
+	version->file_tweak = g_version.tweak;
 
 	version->product_major = g_version.major;
 	version->product_minor = g_version.minor;
-	version->product_tweak = g_version.tweak;
 	version->product_patch = g_version.patch;
+	version->product_tweak = g_version.tweak;
 }
 
 static int GetEditorBuild(void* pEditor)
@@ -46,7 +46,7 @@ static int GetEditorBuild(void* pEditor)
 		throw StringFormat_SysError("Failed to get the editor version!");
 	}
 
-	return g_version.patch;
+	return g_version.tweak;
 }
 
 static void VerifyEditorBuild(int editorBuild)

--- a/Code/Launcher/LauncherCommon.cpp
+++ b/Code/Launcher/LauncherCommon.cpp
@@ -104,7 +104,7 @@ int LauncherCommon::GetGameBuild(void* pCrySystem)
 		throw StringFormat_SysError("Failed to get the game version!");
 	}
 
-	return version.patch;
+	return version.tweak;
 }
 
 void LauncherCommon::VerifyGameBuild(int gameBuild)
@@ -315,6 +315,23 @@ void LauncherCommon::OnChangeUserPath(ISystem* pSystem, const char* userPath)
 	SetUserDir(PathTools::Join(PathTools::GetDocumentsPath(), userPath).c_str());
 }
 
+static void LogRealWindowsBuild()
+{
+	void* kernel32 = OS::DLL::Get("kernel32.dll");
+	if (!kernel32)
+	{
+		return;
+	}
+
+	OS::DLL::Version ver;
+	if (!OS::DLL::GetVersion(kernel32, ver))
+	{
+		return;
+	}
+
+	CryLogAlways("Windows build: %hu.%hu.%hu (real)", ver.major, ver.minor, ver.patch);
+}
+
 void LauncherCommon::OnEarlyEngineInit(ISystem* pSystem, const char* banner)
 {
 	gEnv = pSystem->GetGlobalEnvironment();
@@ -328,6 +345,8 @@ void LauncherCommon::OnEarlyEngineInit(ISystem* pSystem, const char* banner)
 	CryLogAlways("Main directory: %s", mainDir.c_str());
 	CryLogAlways("Root directory: %s", rootDir.empty() ? mainDir.c_str() : rootDir.c_str());
 	CryLogAlways("User directory: %s", userDir.c_str());
+
+	LogRealWindowsBuild();
 
 	CrashTest::Register();
 }

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -137,13 +137,13 @@ namespace MemoryPatch
 	{
 		struct Version
 		{
-			int file_patch;
 			int file_tweak;
+			int file_patch;
 			int file_minor;
 			int file_major;
 
-			int product_patch;
 			int product_tweak;
+			int product_patch;
 			int product_minor;
 			int product_major;
 		};

--- a/Code/Library/OS.cpp
+++ b/Code/Library/OS.cpp
@@ -137,8 +137,8 @@ bool OS::DLL::GetVersion(void* dll, Version& result)
 
 	result.major = HIWORD(fileInfo->dwProductVersionMS);
 	result.minor = LOWORD(fileInfo->dwProductVersionMS);
-	result.tweak = HIWORD(fileInfo->dwProductVersionLS);
-	result.patch = LOWORD(fileInfo->dwProductVersionLS);
+	result.patch = HIWORD(fileInfo->dwProductVersionLS);
+	result.tweak = LOWORD(fileInfo->dwProductVersionLS);
 
 	return true;
 }

--- a/Code/Library/OS.h
+++ b/Code/Library/OS.h
@@ -135,10 +135,10 @@ namespace OS
 		{
 			unsigned short major;
 			unsigned short minor;
-			unsigned short tweak;
 			unsigned short patch;
+			unsigned short tweak;
 
-			Version() : major(), minor(), tweak(), patch() {}
+			Version() : major(), minor(), patch(), tweak() {}
 		};
 
 		bool GetVersion(void* dll, Version& result);


### PR DESCRIPTION
CrySystem cannot see beyond Windows 8 (6.2.9200). It logs the following on Windows 11 24H2 (10.0.26100):

```
Windows 64 bit (build 6.2.9200)
```

Now there is another entry with the real version:

```
Windows build: 10.0.26100 (real)
```

Also fix swapped `patch` and `tweak` numbers in `OS::DLL::Version`.