### PR TITLE
Use UTF-8 code page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Notable changes in each release.
 
 ## [Unreleased]
+- Add support for Unicode paths ([#62](https://github.com/ccomrade/c1-launcher/pull/62)).
+This fixes inaccessible user directory due to Unicode characters in Documents path.
 - Add real Windows version to the log. CrySystem cannot see beyond Windows 8 (6.2.9200).
 - Fix 64-bit memory allocator in FMOD ([#61](https://github.com/ccomrade/c1-launcher/pull/61)).
 - Fix startup crash when `profile.xml` is corrupted ([#59](https://github.com/ccomrade/c1-launcher/pull/59)).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(GAME_LAUNCHER_MANIFESTS
 	${PROJECT_SOURCE_DIR}/Resources/Manifests/EnableVisualStyles.manifest
 	${PROJECT_SOURCE_DIR}/Resources/Manifests/TrustInfo.manifest
 	${PROJECT_SOURCE_DIR}/Resources/Manifests/VC80_CRT.manifest
+	${PROJECT_SOURCE_DIR}/Resources/Manifests/UTF-8.manifest
 )
 
 ################################################################################
@@ -147,6 +148,7 @@ add_executable(CrysisDedicatedServer WIN32
 	Resources/Manifests/EnableVisualStyles.manifest
 	Resources/Manifests/TrustInfo.manifest
 	Resources/Manifests/VC80_CRT.manifest
+	Resources/Manifests/UTF-8.manifest
 )
 
 target_link_libraries(CrysisDedicatedServer LauncherBase)
@@ -163,6 +165,7 @@ add_executable(CrysisHeadlessServer
 	Resources/HeadlessServer.rc
 	Resources/Manifests/TrustInfo.manifest
 	Resources/Manifests/VC80_CRT.manifest
+	Resources/Manifests/UTF-8.manifest
 )
 
 target_link_libraries(CrysisHeadlessServer LauncherBase)
@@ -179,6 +182,7 @@ add_executable(EditorLauncher WIN32
 	Resources/Manifests/TrustInfo.manifest
 	Resources/Manifests/VC80_CRT.manifest
 	Resources/Manifests/VC80_MFC.manifest
+	Resources/Manifests/UTF-8.manifest
 )
 
 target_link_libraries(EditorLauncher LauncherBase)

--- a/Resources/Manifests/UTF-8.manifest
+++ b/Resources/Manifests/UTF-8.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="..." version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page for more info.

This elegant trick fixes https://github.com/ccomrade/c1-launcher/issues/51#issuecomment-2629351813.

Unicode characters in My Documents path are now supported:

```
User directory: C:\Users\dhryz\OneDrive\マイドキュメント\My Games\Crysis
```
