### PR TITLE
Fix loading mods via in-game Mods menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes in each release.
 
+## [Unreleased]
+- Fix loading mods via in-game Mods menu ([#69](https://github.com/ccomrade/c1-launcher/pull/69)).
+
 ## [v7] - 2025-05-11
 - Add support for Unicode paths ([#62](https://github.com/ccomrade/c1-launcher/pull/62)).
 This fixes inaccessible user directory due to Unicode characters in Documents path.

--- a/Code/Launcher/Game/GameLauncher.cpp
+++ b/Code/Launcher/Game/GameLauncher.cpp
@@ -115,6 +115,7 @@ void GameLauncher::PatchEngine()
 	{
 		MemoryPatch::CryGame::CanJoinDX10Servers(m_dlls.pCryGame, m_dlls.gameBuild);
 		MemoryPatch::CryGame::EnableDX10Menu(m_dlls.pCryGame, m_dlls.gameBuild);
+		MemoryPatch::CryGame::FixModLoad(m_dlls.pCryGame, m_dlls.gameBuild);
 		MemoryPatch::CryGame::HookCryWarning(m_dlls.pCryGame, m_dlls.gameBuild,
 			&LauncherCommon::OnCryWarning);
 		MemoryPatch::CryGame::HookGameWarning(m_dlls.pCryGame, m_dlls.gameBuild,

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -23,6 +23,7 @@ namespace MemoryPatch
 		void DisableIntros(void* pCryGame, int gameBuild);
 		void CanJoinDX10Servers(void* pCryGame, int gameBuild);
 		void EnableDX10Menu(void* pCryGame, int gameBuild);
+		void FixModLoad(void* pCryGame, int gameBuild);
 		void HookGameWarning(void* pCryGame, int gameBuild, void (*handler)(const char* format, ...));
 		void HookCryWarning(void* pCryGame, int gameBuild,
 			void (*handler)(int, int, const char* format, ...));


### PR DESCRIPTION
Mods menu is now able to load mods whose name in the `info.xml` file is different from their directory name.

For example, `Mods/CryNoire/info.xml`:

```xml
<Mod Name="Cry Noire Mod v1.4" Team="Smoother" Version="Release v1.4" Screenshot="modpreview.dds" Description="" url="https://www.moddb.com/mods/cry-noire-mod-for-crysis"/>
```

- Mod name: `Cry Noire Mod v1.4` (shown in Mods menu)
- Mod directory name: `CryNoire` (used to load the mod: `-mod CryNoire`)

It wasn't possible to load such mods via Mods menu before.

See #66.