### PR TITLE
Fix 64-bit pointer truncation in CryMemoryAllocator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   msvc_vs2022:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes in each release.
 - Add support for Crysis MP Beta ([#77](https://github.com/ccomrade/c1-launcher/pull/77) by
 [illusion0001](https://github.com/illusion0001)).
 - Disable DPI awareness for editor ([#83](https://github.com/ccomrade/c1-launcher/pull/83)).
+- Fix 64-bit crashes due to high memory usage ([#84](https://github.com/ccomrade/c1-launcher/pull/84)).
 - Fix editor crash in `oleacc.AccessibleObjectFromWindow` ([#79](https://github.com/ccomrade/c1-launcher/pull/79)).
 - Fix loading mods via in-game Mods menu ([#69](https://github.com/ccomrade/c1-launcher/pull/69)).
 - Revert sys_crashtest improvements ([#71](https://github.com/ccomrade/c1-launcher/pull/71)).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(LauncherBase STATIC
 	Code/CryCommon/CrySystem/IValidator.h
 	Code/Launcher/CPUInfo.cpp
 	Code/Launcher/CPUInfo.h
+	Code/Launcher/CryMallocHook.cpp
+	Code/Launcher/CryMallocHook.h
 	Code/Launcher/LauncherCommon.cpp
 	Code/Launcher/LauncherCommon.h
 	Code/Launcher/MemoryPatch.cpp

--- a/Code/Launcher/CryMallocHook.cpp
+++ b/Code/Launcher/CryMallocHook.cpp
@@ -1,0 +1,332 @@
+#include "CryMallocHook.h"
+
+// CryMemoryAllocator is used by CryEngine at various places. For example, as
+// the default allocator of STLport, which is the C++ Standard Library within
+// the engine, as Lua allocator in CryScriptSystem, and as FMOD allocator in
+// CrySoundSystem. It's inlined all over the place in engine DLLs.
+
+// CryMemoryAllocator contains a critical bug that causes 64-bit pointers to be
+// truncated to 32-bit. It results in memory corruption and a crash when any
+// instance of the allocator uses memory above 4 GB. This bug exists only in the
+// 64-bit build because the 32-bit one cannot address more than 4 GB of memory.
+
+// The following fix is based on the fact that CryMemoryAllocator allocates
+// fixed size blocks from its upstream allocator, which is the global CryMalloc.
+// The block size is 0x80000 (512 * 1024) and appears to be the same for all
+// CryMemoryAllocator instances within the engine. Therefore, before starting
+// the engine, we preallocate a large pool of these blocks below 4 GB, hook
+// CryMalloc, and redirect requests for these blocks to the pool. This ensures
+// that CryMemoryAllocator only gets safe blocks below 4 GB.
+
+// This fix was originally created for the CryMP project.
+
+#ifdef BUILD_64BIT
+
+// std::malloc
+#include <cstdlib>
+
+// VirtualAlloc, _InterlockedIncrement64, etc.
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "Library/CrashLogger.h"
+#include "Library/OS.h"
+
+#define SAFE_BLOCK_SIZE 0x80000
+#define SAFE_BLOCK_COUNT 2048  // 0x80000 * 2048 = 1 GiB should be enough for anyone
+
+struct Stats : public CrashLogger::ExtraProvider
+{
+	volatile __int64 mallocCalls;
+	volatile __int64 reallocCalls;
+	volatile __int64 freeCalls;
+	volatile __int64 sizeCalls;
+	volatile __int64 crtMallocCalls;
+	volatile __int64 crtFreeCalls;
+	volatile __int64 crtSizeCalls;
+
+	volatile __int64 safePoolBlocks;
+	volatile __int64 safePoolFreeBlocks;
+	volatile __int64 safePoolAllocs;
+	volatile __int64 safePoolFailedAllocs;
+	volatile __int64 safePoolDeallocs;
+
+	Stats() : mallocCalls(0), reallocCalls(0), freeCalls(0), sizeCalls(0), crtMallocCalls(0), crtFreeCalls(0),
+		crtSizeCalls(0), safePoolBlocks(0), safePoolFreeBlocks(0), safePoolAllocs(0), safePoolFailedAllocs(0),
+		safePoolDeallocs(0) {}
+
+	void OnCrash(std::FILE* file) override
+	{
+		std::fprintf(file, "CryMallocHook:\n");
+
+		std::fprintf(file, "Calls:\n");
+		std::fprintf(file, "Malloc = %I64d + %I64d\n", this->mallocCalls, this->crtMallocCalls);
+		std::fprintf(file, "Realloc = %I64d\n", this->reallocCalls);
+		std::fprintf(file, "Free = %I64d + %I64d\n", this->freeCalls, this->crtFreeCalls);
+		std::fprintf(file, "Size = %I64d + %I64d\n", this->sizeCalls, this->crtSizeCalls);
+
+		std::fprintf(file, "SafePool:\n");
+		std::fprintf(file, "Blocks = %I64d (%I64d free)\n", this->safePoolBlocks, this->safePoolFreeBlocks);
+		std::fprintf(file, "Allocs = %I64d (%I64d failed)\n", this->safePoolAllocs, this->safePoolFailedAllocs);
+		std::fprintf(file, "Deallocs = %I64d\n", this->safePoolDeallocs);
+	}
+};
+
+static Stats g_stats;
+
+class SafePool
+{
+	void* m_pool;
+	unsigned int m_blockCount;
+	void* m_freeList;
+	void* m_freeListLast;
+	OS::Mutex m_mutex;
+
+public:
+	SafePool() : m_pool(NULL), m_blockCount(0), m_freeList(NULL), m_freeListLast(NULL), m_mutex()
+	{
+		// use 0x80000000 .. 0xc0000000 for the pool to avoid interfering with DLL placement
+		void* hint = reinterpret_cast<void*>(0x80000000UL);
+
+		void* pool = VirtualAlloc(hint, SAFE_BLOCK_SIZE * SAFE_BLOCK_COUNT, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+		if (!pool)
+		{
+			return;
+		}
+
+		if (pool != hint)
+		{
+			VirtualFree(pool, 0, MEM_RELEASE);
+			return;
+		}
+
+		m_pool = pool;
+
+		int i = 0;
+		for (; i < SAFE_BLOCK_COUNT; i++)
+		{
+			ULONG_PTR address = reinterpret_cast<ULONG_PTR>(pool) + (i * SAFE_BLOCK_SIZE);
+
+			// make sure the whole block is below 4 GB
+			if ((address + SAFE_BLOCK_SIZE) > 0x100000000ULL)
+			{
+				break;
+			}
+
+			void* block = reinterpret_cast<void*>(address);
+
+			if (!m_freeList)
+			{
+				m_freeList = block;
+				m_freeListLast = block;
+			}
+			else
+			{
+				*static_cast<void**>(m_freeListLast) = block;
+				m_freeListLast = block;
+			}
+		}
+
+		m_blockCount = i;
+		g_stats.safePoolBlocks = i;
+		g_stats.safePoolFreeBlocks = i;
+	}
+
+	void* Allocate()
+	{
+		_InterlockedIncrement64(&g_stats.safePoolAllocs);
+
+		OS::LockGuard<OS::Mutex> lock(m_mutex);
+
+		if (!m_freeList)
+		{
+			_InterlockedIncrement64(&g_stats.safePoolFailedAllocs);
+			return NULL;
+		}
+
+		void* block = m_freeList;
+
+		if (m_freeList == m_freeListLast)
+		{
+			m_freeList = NULL;
+			m_freeListLast = NULL;
+		}
+		else
+		{
+			m_freeList = *static_cast<void**>(m_freeList);
+		}
+
+		_InterlockedDecrement64(&g_stats.safePoolFreeBlocks);
+
+		return block;
+	}
+
+	void Deallocate(void* block)
+	{
+		_InterlockedIncrement64(&g_stats.safePoolDeallocs);
+
+		OS::LockGuard<OS::Mutex> lock(m_mutex);
+
+		if (!m_freeList)
+		{
+			m_freeList = block;
+			m_freeListLast = block;
+		}
+		else
+		{
+			*static_cast<void**>(m_freeListLast) = block;
+			m_freeListLast = block;
+		}
+
+		_InterlockedIncrement64(&g_stats.safePoolFreeBlocks);
+	}
+
+	bool Contains(void* ptr) const
+	{
+		const ULONG_PTR address = reinterpret_cast<ULONG_PTR>(ptr);
+		const ULONG_PTR poolBegin = reinterpret_cast<ULONG_PTR>(m_pool);
+		const ULONG_PTR poolEnd = poolBegin + (m_blockCount * SAFE_BLOCK_SIZE);
+
+		return address >= poolBegin && address < poolEnd && !(address % SAFE_BLOCK_SIZE);
+	}
+};
+
+static SafePool* g_safePool = NULL;
+
+typedef void* (*TCryMalloc)(size_t, size_t&);
+typedef void* (*TCryRealloc)(void*, size_t, size_t&);
+typedef size_t (*TCryFree)(void*);
+typedef size_t (*TCryGetMemSize)(void*, size_t);
+typedef void* (*TCryCrtMalloc)(size_t);
+typedef void (*TCryCrtFree)(void*);
+typedef size_t (*TCryCrtSize)(void*);
+
+// needed during loading of CrySystem.dll
+static void* CryMallocStub(size_t size, size_t& allocated)
+{
+	allocated = size;
+	return std::malloc(size);
+}
+
+static TCryMalloc g_pCryMalloc = &CryMallocStub;
+static TCryRealloc g_pCryRealloc = NULL;
+static TCryFree g_pCryFree = NULL;
+static TCryGetMemSize g_pCryGetMemSize = NULL;
+static TCryCrtMalloc g_pCryCrtMalloc = NULL;
+static TCryCrtFree g_pCryCrtFree = NULL;
+static TCryCrtSize g_pCryCrtSize = NULL;
+
+// CryMalloc functions exported by the EXE are automatically used instead of CrySystem.dll ones
+#define HOOKED extern "C" __declspec(dllexport)
+
+HOOKED void* CryMalloc(size_t size, size_t& allocated)
+{
+	_InterlockedIncrement64(&g_stats.mallocCalls);
+
+	if (g_safePool && size == SAFE_BLOCK_SIZE)
+	{
+		void* block = g_safePool->Allocate();
+		if (block)
+		{
+			allocated = SAFE_BLOCK_SIZE;
+			return block;
+		}
+	}
+
+	return g_pCryMalloc(size, allocated);
+}
+
+HOOKED void* CryRealloc(void* memblock, size_t size, size_t& allocated)
+{
+	_InterlockedIncrement64(&g_stats.reallocCalls);
+
+	return g_pCryRealloc(memblock, size, allocated);
+}
+
+HOOKED size_t CryFree(void* p)
+{
+	_InterlockedIncrement64(&g_stats.freeCalls);
+
+	if (g_safePool && g_safePool->Contains(p))
+	{
+		g_safePool->Deallocate(p);
+		return SAFE_BLOCK_SIZE;
+	}
+
+	return g_pCryFree(p);
+}
+
+HOOKED size_t CryGetMemSize(void* p, size_t size)
+{
+	_InterlockedIncrement64(&g_stats.sizeCalls);
+
+	if (g_safePool && g_safePool->Contains(p))
+	{
+		return SAFE_BLOCK_SIZE;
+	}
+
+	return g_pCryGetMemSize(p, size);
+}
+
+HOOKED void* CrySystemCrtMalloc(size_t size)
+{
+	_InterlockedIncrement64(&g_stats.crtMallocCalls);
+
+	if (g_safePool && size == SAFE_BLOCK_SIZE)
+	{
+		void* block = g_safePool->Allocate();
+		if (block)
+		{
+			return block;
+		}
+	}
+
+	return g_pCryCrtMalloc(size);
+}
+
+HOOKED void CrySystemCrtFree(void* p)
+{
+	_InterlockedIncrement64(&g_stats.crtFreeCalls);
+
+	if (g_safePool && g_safePool->Contains(p))
+	{
+		g_safePool->Deallocate(p);
+		return;
+	}
+
+	g_pCryCrtFree(p);
+}
+
+HOOKED size_t CrySystemCrtSize(void* p)
+{
+	_InterlockedIncrement64(&g_stats.crtSizeCalls);
+
+	if (g_safePool && g_safePool->Contains(p))
+	{
+		return SAFE_BLOCK_SIZE;
+	}
+
+	return g_pCryCrtSize(p);
+}
+
+#endif  // BUILD_64BIT
+
+void CryMallocHook::Init(void* pCrySystem)
+{
+#ifdef BUILD_64BIT
+	CrashLogger::AddExtraProvider(&g_stats);
+
+	if (!OS::CmdLine::HasArg("-nosafepool"))
+	{
+		g_safePool = new SafePool;
+	}
+
+	g_pCryMalloc = static_cast<TCryMalloc>(OS::DLL::FindSymbol(pCrySystem, "CryMalloc"));
+	g_pCryRealloc = static_cast<TCryRealloc>(OS::DLL::FindSymbol(pCrySystem, "CryRealloc"));
+	g_pCryFree = static_cast<TCryFree>(OS::DLL::FindSymbol(pCrySystem, "CryFree"));
+	g_pCryGetMemSize = static_cast<TCryGetMemSize>(OS::DLL::FindSymbol(pCrySystem, "CryGetMemSize"));
+	g_pCryCrtMalloc = static_cast<TCryCrtMalloc>(OS::DLL::FindSymbol(pCrySystem, "CrySystemCrtMalloc"));
+	g_pCryCrtFree = static_cast<TCryCrtFree>(OS::DLL::FindSymbol(pCrySystem, "CrySystemCrtFree"));
+	g_pCryCrtSize = static_cast<TCryCrtSize>(OS::DLL::FindSymbol(pCrySystem, "CrySystemCrtSize"));
+#endif
+}

--- a/Code/Launcher/CryMallocHook.cpp
+++ b/Code/Launcher/CryMallocHook.cpp
@@ -86,7 +86,7 @@ public:
 	SafePool() : m_pool(NULL), m_blockCount(0), m_freeList(NULL), m_freeListLast(NULL), m_mutex()
 	{
 		// use 0x80000000 .. 0xc0000000 for the pool to avoid interfering with DLL placement
-		void* hint = reinterpret_cast<void*>(0x80000000UL);
+		void* hint = reinterpret_cast<void*>(0x80000000ULL);
 
 		void* pool = VirtualAlloc(hint, SAFE_BLOCK_SIZE * SAFE_BLOCK_COUNT, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 		if (!pool)

--- a/Code/Launcher/CryMallocHook.h
+++ b/Code/Launcher/CryMallocHook.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace CryMallocHook
+{
+	void Init(void* pCrySystem);
+}

--- a/Code/Launcher/DedicatedServer/DedicatedServerLauncher.cpp
+++ b/Code/Launcher/DedicatedServer/DedicatedServerLauncher.cpp
@@ -3,6 +3,7 @@
 #include "Project.h"
 
 #include "../CPUInfo.h"
+#include "../CryMallocHook.h"
 #include "../LauncherCommon.h"
 #include "../MemoryPatch.h"
 
@@ -59,6 +60,8 @@ void DedicatedServerLauncher::LoadEngine()
 	m_dlls.pCrySystem = LauncherCommon::LoadDLL("CrySystem.dll");
 	m_dlls.gameBuild = LauncherCommon::GetGameBuild(m_dlls.pCrySystem);
 	LauncherCommon::VerifyGameBuild(m_dlls.gameBuild);
+
+	CryMallocHook::Init(m_dlls.pCrySystem);
 
 	if (LauncherCommon::IsCrysisWarhead(m_dlls.gameBuild))
 	{

--- a/Code/Launcher/Editor/EditorLauncher.cpp
+++ b/Code/Launcher/Editor/EditorLauncher.cpp
@@ -155,6 +155,8 @@ void EditorLauncher::LoadEngine()
 	m_dlls.pFMODEx = LauncherCommon::LoadDLL("fmodex.dll");
 #endif
 
+	m_dlls.pCrySoundSystem = LauncherCommon::LoadDLL("CrySoundSystem.dll");
+
 #ifdef BUILD_64BIT
 	m_dlls.pXToolkitPro = LauncherCommon::LoadDLL("ToolkitPro1042vc80x64.dll");
 #else
@@ -226,6 +228,11 @@ void EditorLauncher::PatchEngine()
 			&LauncherCommon::OnD3D10Info);
 		MemoryPatch::CryRenderD3D10::HookInitAPI(m_dlls.pCryRenderD3D10, m_dlls.gameBuild,
 			&LauncherCommon::OnD3D10Init);
+	}
+
+	if (m_dlls.pCrySoundSystem)
+	{
+		MemoryPatch::CrySoundSystem::FixAllocForFmod(m_dlls.pCrySoundSystem, m_dlls.gameBuild);
 	}
 
 	if (m_dlls.pFMODEx && LauncherCommon::IsFMODExVersionCorrect(m_dlls.pFMODEx, m_dlls.gameBuild))

--- a/Code/Launcher/Editor/EditorLauncher.cpp
+++ b/Code/Launcher/Editor/EditorLauncher.cpp
@@ -4,6 +4,7 @@
 #include "Project.h"
 
 #include "../CPUInfo.h"
+#include "../CryMallocHook.h"
 #include "../LauncherCommon.h"
 #include "../MemoryPatch.h"
 
@@ -120,6 +121,8 @@ void EditorLauncher::LoadEngine()
 	m_dlls.pCrySystem = LauncherCommon::LoadDLL("CrySystem.dll");
 	m_dlls.gameBuild = LauncherCommon::GetGameBuild(m_dlls.pCrySystem);
 	LauncherCommon::VerifyGameBuild(m_dlls.gameBuild);
+
+	CryMallocHook::Init(m_dlls.pCrySystem);
 
 	m_dlls.pEditor = LauncherCommon::LoadEXE("Editor.exe");
 	m_dlls.editorBuild = GetEditorBuild(m_dlls.pEditor);

--- a/Code/Launcher/Editor/EditorLauncher.h
+++ b/Code/Launcher/Editor/EditorLauncher.h
@@ -12,6 +12,7 @@ class EditorLauncher
 		void* pCrySystem;
 		void* pCryRenderD3D9;
 		void* pCryRenderD3D10;
+		void* pCrySoundSystem;
 		void* pFMODEx;
 		void* pXToolkitPro;
 

--- a/Code/Launcher/Game/GameLauncher.cpp
+++ b/Code/Launcher/Game/GameLauncher.cpp
@@ -3,6 +3,7 @@
 #include "Project.h"
 
 #include "../CPUInfo.h"
+#include "../CryMallocHook.h"
 #include "../LauncherCommon.h"
 #include "../MemoryPatch.h"
 
@@ -60,6 +61,8 @@ void GameLauncher::LoadEngine()
 	m_dlls.gameBuild = LauncherCommon::GetGameBuild(m_dlls.pCrySystem);
 	const bool isCryisMPBeta4804 = m_dlls.gameBuild == 4804;
 	LauncherCommon::VerifyGameBuild(m_dlls.gameBuild);
+
+	CryMallocHook::Init(m_dlls.pCrySystem);
 
 	if (LauncherCommon::IsCrysisWarhead(m_dlls.gameBuild))
 	{

--- a/Code/Launcher/Game/GameLauncher.cpp
+++ b/Code/Launcher/Game/GameLauncher.cpp
@@ -92,6 +92,8 @@ void GameLauncher::LoadEngine()
 #else
 		m_dlls.pFMODEx = LauncherCommon::LoadDLL(isCryisMPBeta4804 ? "fmodexL.dll" : "fmodex.dll");
 #endif
+
+		m_dlls.pCrySoundSystem = LauncherCommon::LoadDLL("CrySoundSystem.dll");
 	}
 }
 
@@ -179,6 +181,11 @@ void GameLauncher::PatchEngine()
 			&LauncherCommon::OnD3D10Info);
 		MemoryPatch::CryRenderD3D10::HookInitAPI(m_dlls.pCryRenderD3D10, m_dlls.gameBuild,
 			&LauncherCommon::OnD3D10Init);
+	}
+
+	if (m_dlls.pCrySoundSystem)
+	{
+		MemoryPatch::CrySoundSystem::FixAllocForFmod(m_dlls.pCrySoundSystem, m_dlls.gameBuild);
 	}
 
 	if (m_dlls.pFMODEx && LauncherCommon::IsFMODExVersionCorrect(m_dlls.pFMODEx, m_dlls.gameBuild))

--- a/Code/Launcher/Game/GameLauncher.h
+++ b/Code/Launcher/Game/GameLauncher.h
@@ -17,6 +17,7 @@ class GameLauncher
 		void* pCrySystem;
 		void* pCryRenderD3D9;
 		void* pCryRenderD3D10;
+		void* pCrySoundSystem;
 		void* pFMODEx;
 
 		int gameBuild;

--- a/Code/Launcher/HeadlessServer/HeadlessServerLauncher.cpp
+++ b/Code/Launcher/HeadlessServer/HeadlessServerLauncher.cpp
@@ -7,6 +7,7 @@
 #include "Project.h"
 
 #include "../CPUInfo.h"
+#include "../CryMallocHook.h"
 #include "../LauncherCommon.h"
 #include "../MemoryPatch.h"
 
@@ -99,6 +100,8 @@ void HeadlessServerLauncher::LoadEngine()
 	m_dlls.gameBuild = LauncherCommon::GetGameBuild(m_dlls.pCrySystem);
 	Print("Game build: %d", m_dlls.gameBuild);
 	LauncherCommon::VerifyGameBuild(m_dlls.gameBuild);
+
+	CryMallocHook::Init(m_dlls.pCrySystem);
 
 	if (LauncherCommon::IsCrysisWarhead(m_dlls.gameBuild))
 	{

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -123,6 +123,11 @@ namespace MemoryPatch
 		void DisableDebugRenderer(void* pCryRenderNULL, int gameBuild);
 	}
 
+	namespace CrySoundSystem
+	{
+		void FixAllocForFmod(void* pCrySoundSystem, int gameBuild);
+	}
+
 	namespace WarheadEXE
 	{
 		using CryAction::AllowDX9ImmersiveMultiplayer;

--- a/Code/Library/CrashLogger.cpp
+++ b/Code/Library/CrashLogger.cpp
@@ -20,6 +20,7 @@
 #define CRASH_LOGGER_INVALID_PARAM 0xE0C1C102
 #define CRASH_LOGGER_ENGINE_ERROR 0xE0C1C103
 
+static CrashLogger::ExtraProvider* g_extraProvider = NULL;
 static CrashLogger::LogFileProvider g_logFileProvider;
 static const char* g_banner;
 
@@ -404,6 +405,13 @@ static void WriteCrashDump(std::FILE* file, EXCEPTION_POINTERS* exception)
 	DumpLoadedModules(file);
 	DumpCommandLine(file);
 
+	CrashLogger::ExtraProvider* extra = g_extraProvider;
+	while (extra)
+	{
+		extra->OnCrash(file);
+		extra = extra->next;
+	}
+
 	WriteDumpFooter(file);
 }
 
@@ -504,4 +512,21 @@ void CrashLogger::Enable(LogFileProvider logFileProvider, const char* banner)
 		}
 	}
 #endif
+}
+
+void CrashLogger::AddExtraProvider(ExtraProvider* provider)
+{
+	if (!g_extraProvider)
+	{
+		g_extraProvider = provider;
+		return;
+	}
+
+	ExtraProvider* current = g_extraProvider;
+	while (current->next)
+	{
+		current = current->next;
+	}
+
+	current->next = provider;
 }

--- a/Code/Library/CrashLogger.h
+++ b/Code/Library/CrashLogger.h
@@ -9,4 +9,15 @@ namespace CrashLogger
 	void OnEngineError(const char* format, va_list args);
 
 	void Enable(LogFileProvider logFileProvider, const char* banner);
+
+	struct ExtraProvider
+	{
+		ExtraProvider* next;
+
+		ExtraProvider() : next(NULL) {}
+
+		virtual void OnCrash(std::FILE* file) = 0;
+	};
+
+	void AddExtraProvider(ExtraProvider* provider);
 }


### PR DESCRIPTION
This is the fix for 64-bit crashes when memory usage (commit charge) approaches 4 GB. All three games (Crysis, Crysis Warhead, Crysis Wars) are affected by this bug. The fix is applied in all launcher variants (game, editor, dedicated and headless server) for consistency.

It's enabled by default, but for testing purposes, it can be disabled using the new `-nosafepool` command line argument.

The original idea was to fix this by patching all the broken code that truncates 64-bit pointers. However, this approach eventually reached a dead end. The main problem is that the `CryMemoryAllocator` code is inlined at many places. It also cannot be fixed in-place. The reason is that larger 64-bit instructions are needed and manually optimizing surrounding code doesn't create enough room. Unlike in the internal FMOD allocator suffering from the same issue, which was fixed in-place in #61. Here we would need a crazy amount of hooks to fix it this way. Moreover, the inlined code is often unique at each location due to compiler optimizations, which makes hooking unfeasible.

In parallel, I took another approach to fix this issue in the CryMP project. It was merged as part of larger memory allocation changes in https://github.com/crymp-net/crymp-client/pull/112. It's been more than a year since then and the fix is working well. This PR contains the same fix with additional improvements:

- Allocate the safe pool as a single chunk of memory to optimize block lookup.
- Use a specific memory location for the pool to avoid interfering with DLL placement.
- Statistics are collected and added into the crash log.
- Simplified `CryMalloc` hooking.
- Graceful error handling.

The fix has one noticeable side effect. It increases Crysis memory usage (commit charge) by roughly 1 GiB (the size of the safe pool):

<img width="400" height="40" alt="image" src="https://github.com/user-attachments/assets/9f8abb22-d5c0-43b2-ab6b-b83a4d9e54fb" /><br />

Here is how it was before (`-nosafepool`):

<img width="400" height="40" alt="image" src="https://github.com/user-attachments/assets/02a612b3-e60b-49fc-9c3a-dacc0f28deda" /><br />

Note that the actually used memory (working set) has not changed much. No change in the 32-bit version also.